### PR TITLE
Clamp SAFE risk when simulation confidence is not high

### DIFF
--- a/test/cli-risk-simulation-failure.test.ts
+++ b/test/cli-risk-simulation-failure.test.ts
@@ -47,6 +47,7 @@ describe("cli risk label with simulation failures", () => {
 		expect(riskLine).toBeDefined();
 		expect(riskLine).not.toContain("SAFE");
 		expect(riskLine).toContain("LOW");
+		expect(output).not.toContain("- None detected");
 	});
 
 	test("AI enabled + simulation missing + calldata never shows SAFE", () => {
@@ -66,5 +67,34 @@ describe("cli risk label with simulation failures", () => {
 		expect(riskLine).toBeDefined();
 		expect(riskLine).not.toContain("SAFE");
 		expect(riskLine).toContain("LOW");
+		expect(output).not.toContain("- None detected");
+	});
+
+	test("AI enabled + simulation success (low confidence) + calldata never shows SAFE", () => {
+		const analysis: AnalysisResult = {
+			...baseAnalysis(),
+			ai: {
+				risk_score: 5,
+				summary: "No issues detected.",
+				concerns: [],
+				model: "test-model",
+				provider: "openai",
+			},
+			simulation: {
+				success: true,
+				assetChanges: [],
+				approvals: [],
+				confidence: "low",
+				notes: [],
+			},
+		};
+
+		const output = stripAnsi(renderResultBox(analysis, { hasCalldata: true }));
+		const riskLine = output.split("\n").find((line) => line.includes("📊 RISK:"));
+		expect(riskLine).toBeDefined();
+		expect(riskLine).not.toContain("SAFE");
+		expect(riskLine).toContain("LOW");
+		expect(output).toContain("No balance changes detected (low confidence)");
+		expect(output).toContain("None detected (low confidence)");
 	});
 });


### PR DESCRIPTION
### Why
We could show balance deltas marked `(low confidence)` while still printing `📊 RISK: SAFE`, which is misleading.

### What
- If calldata is present and the simulation is **missing**, **failed**, or **succeeded with confidence != high**, the displayed risk label is clamped so it never shows `SAFE` (becomes `LOW`).
- When a simulation succeeds with non-high confidence and we otherwise would show “No balance changes detected” / “None detected”, we now include the confidence note to avoid overclaiming certainty.

### Before/After
**Before** (example)
```
💰 BALANCE CHANGES
- 0.01 ETH (low confidence)
📊 RISK: SAFE
```

**After**
```
💰 BALANCE CHANGES
- 0.01 ETH (low confidence)
📊 RISK: LOW
```

### Tests
- `bun test`