### PR TITLE
feat(sim): detect Permit2 approvals/permits from simulation logs

### DIFF
--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -577,20 +577,25 @@ function formatSimulationApproval(approval: BalanceSimulationResult["approvals"]
 } {
 	const tokenLabel = shortenAddress(approval.token);
 	const spenderLabel = shortenAddress(approval.spender);
+	const prefix = approval.standard === "permit2" ? "PERMIT2 " : "";
 
 	if (approval.scope === "all") {
 		const approved = approval.approved !== false;
 		const label = approved ? "ALL" : "REVOKE ALL";
 		return {
-			text: `${tokenLabel}: ${label} to ${spenderLabel}`,
+			text: `${prefix}${tokenLabel}: ${label} to ${spenderLabel}`,
 			isUnlimited: approved,
 			key: `${tokenLabel}|${spenderLabel}|all`,
 		};
 	}
 
-	if (approval.tokenId !== undefined && approval.standard !== "erc20") {
+	if (
+		approval.tokenId !== undefined &&
+		approval.standard !== "erc20" &&
+		approval.standard !== "permit2"
+	) {
 		return {
-			text: `${tokenLabel} #${approval.tokenId.toString()}: APPROVE to ${spenderLabel}`,
+			text: `${prefix}${tokenLabel} #${approval.tokenId.toString()}: APPROVE to ${spenderLabel}`,
 			isUnlimited: false,
 			key: `${tokenLabel}|${spenderLabel}|${approval.tokenId.toString()}`,
 		};
@@ -602,7 +607,7 @@ function formatSimulationApproval(approval: BalanceSimulationResult["approvals"]
 			? "UNLIMITED"
 			: formatApprovalAmount(approval.amount, 18);
 	return {
-		text: `${tokenLabel}: ${amountLabel} to ${spenderLabel}`,
+		text: `${prefix}${tokenLabel}: ${amountLabel} to ${spenderLabel}`,
 		isUnlimited,
 		key: `${tokenLabel}|${spenderLabel}|amount`,
 	};

--- a/src/permit2.ts
+++ b/src/permit2.ts
@@ -1,0 +1,41 @@
+import type { AbiEvent } from "viem";
+import type { Chain } from "./types";
+
+// Uniswap Permit2 (AllowanceTransfer) contract.
+// Docs/interface source: https://github.com/Uniswap/permit2
+export const PERMIT2_CANONICAL_ADDRESS = "0x000000000022d473030f116ddee9f6b43ac78ba3";
+
+export const PERMIT2_ADDRESS: Record<Chain, string> = {
+	ethereum: PERMIT2_CANONICAL_ADDRESS,
+	base: PERMIT2_CANONICAL_ADDRESS,
+	arbitrum: PERMIT2_CANONICAL_ADDRESS,
+	optimism: PERMIT2_CANONICAL_ADDRESS,
+	polygon: PERMIT2_CANONICAL_ADDRESS,
+};
+
+export const PERMIT2_APPROVAL_EVENT: AbiEvent = {
+	anonymous: false,
+	type: "event",
+	name: "Approval",
+	inputs: [
+		{ indexed: true, name: "owner", type: "address" },
+		{ indexed: true, name: "token", type: "address" },
+		{ indexed: true, name: "spender", type: "address" },
+		{ indexed: false, name: "amount", type: "uint160" },
+		{ indexed: false, name: "expiration", type: "uint48" },
+	],
+};
+
+export const PERMIT2_PERMIT_EVENT: AbiEvent = {
+	anonymous: false,
+	type: "event",
+	name: "Permit",
+	inputs: [
+		{ indexed: true, name: "owner", type: "address" },
+		{ indexed: true, name: "token", type: "address" },
+		{ indexed: true, name: "spender", type: "address" },
+		{ indexed: false, name: "amount", type: "uint160" },
+		{ indexed: false, name: "expiration", type: "uint48" },
+		{ indexed: false, name: "nonce", type: "uint48" },
+	],
+};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -151,7 +151,7 @@ const assetChangeSchema = z
 
 const approvalChangeSchema = z
 	.object({
-		standard: z.enum(["erc20", "erc721", "erc1155"]),
+		standard: z.enum(["erc20", "erc721", "erc1155", "permit2"]),
 		token: addressSchema,
 		owner: addressSchema,
 		spender: addressSchema,

--- a/src/simulations/verdict.ts
+++ b/src/simulations/verdict.ts
@@ -31,7 +31,7 @@ function applySimulationDrainerHeuristics(
 	const originalCount = findings.length;
 
 	const unlimitedApprovals = simulation.approvals.filter((approval) => {
-		if (approval.standard !== "erc20") return false;
+		if (approval.standard !== "erc20" && approval.standard !== "permit2") return false;
 		if (approval.amount !== MAX_UINT256) return false;
 		if (isKnownSpender(knownSpenders, approval.spender)) return false;
 		return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,7 +164,7 @@ export interface AssetChange {
 }
 
 export interface ApprovalChange {
-	standard: "erc20" | "erc721" | "erc1155";
+	standard: "erc20" | "erc721" | "erc1155" | "permit2";
 	token: string;
 	owner: string;
 	spender: string;

--- a/test/logs-permit2.test.ts
+++ b/test/logs-permit2.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { encodeAbiParameters, encodeEventTopics, type Hex, type Log } from "viem";
+import { PERMIT2_APPROVAL_EVENT, PERMIT2_CANONICAL_ADDRESS } from "../src/permit2";
+import { parseReceiptLogs } from "../src/simulations/logs";
+
+const ZERO_32: Hex = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+describe("parseReceiptLogs - Permit2", () => {
+	test("captures Permit2 Approval events as permit2 approvals", async () => {
+		const owner = "0x24274566a1ad6a9b056e8e2618549ebd2f5141a7";
+		const token = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+		const spender = "0x66a9893cc07d91d95644aedd05d03f95e1dba8af";
+
+		const topics = encodeEventTopics({
+			abi: [PERMIT2_APPROVAL_EVENT],
+			eventName: "Approval",
+			args: { owner, token, spender },
+		});
+		const data = encodeAbiParameters(
+			[
+				{ type: "uint160", name: "amount" },
+				{ type: "uint48", name: "expiration" },
+			],
+			[(1n << 160n) - 1n, 0n],
+		);
+
+		const log: Log = {
+			address: PERMIT2_CANONICAL_ADDRESS,
+			topics,
+			data,
+			logIndex: 0,
+			transactionIndex: 0,
+			transactionHash: ZERO_32,
+			blockHash: ZERO_32,
+			blockNumber: 1n,
+			removed: false,
+		};
+
+		const client = {
+			readContract: async () => false,
+		};
+
+		const result = await parseReceiptLogs([log], client);
+		expect(result.approvals.length).toBe(1);
+		const approval = result.approvals[0];
+		expect(approval.standard).toBe("permit2");
+		expect(approval.owner.toLowerCase()).toBe(owner.toLowerCase());
+		expect(approval.token.toLowerCase()).toBe(token.toLowerCase());
+		expect(approval.spender.toLowerCase()).toBe(spender.toLowerCase());
+		expect(approval.amount).toBe((1n << 160n) - 1n);
+		expect(approval.scope).toBe("token");
+	});
+});


### PR DESCRIPTION
Adds Permit2 awareness to the simulation layer by parsing Permit2 `Approval`/`Permit` events emitted by the Permit2 contract and surfacing them as approval diffs.

Includes:
- `src/permit2.ts`: Permit2 canonical address + event ABI
- `parseReceiptLogs`: detects Permit2 Approval/Permit logs and emits `standard=permit2` approvals
- CLI UI: prefixes Permit2 approvals with `PERMIT2` for clarity
- Verdict heuristics: treat unlimited Permit2 approvals like unlimited ERC20 approvals (risk bump)
- Test: `test/logs-permit2.test.ts`

Rationale: Permit2 is a common path in modern drainer txs; without parsing its events, we miss the permission diff.
