### PR TITLE
feat(cli): checks section + ‘You’ labeling + better approvals

### DIFF
--- a/src/approvals/known-spenders.ts
+++ b/src/approvals/known-spenders.ts
@@ -27,6 +27,10 @@ export const KNOWN_SPENDERS: Record<Chain, KnownSpender[]> = {
 			name: "SushiSwap Router",
 			address: "0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f",
 		},
+		{
+			name: "1inch Router",
+			address: "0x6131b5fae19ea4f9d964eac0408e4408b66337b5",
+		},
 	],
 	base: [
 		{

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -272,7 +272,10 @@ async function runScan(args: string[]) {
 				? JSON.stringify(response, null, 2)
 				: format === "sarif"
 					? JSON.stringify(formatSarif(response), null, 2)
-					: renderResultBox(analysis, { hasCalldata: Boolean(parsed.data.calldata) });
+					: renderResultBox(analysis, {
+							hasCalldata: Boolean(parsed.data.calldata),
+							sender: parsed.data.calldata?.from,
+						});
 
 		await writeOutput(output, outputPayload, format === "text");
 

--- a/src/jsonrpc/proxy.ts
+++ b/src/jsonrpc/proxy.ts
@@ -390,6 +390,7 @@ async function defaultScanFn(
 		? undefined
 		: `${renderHeading(`Tx scan on ${options.chain}`)}\n\n${renderResultBox(analysis, {
 				hasCalldata: Boolean(input.calldata),
+				sender: input.calldata?.from,
 			})}\n`;
 
 	return {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -260,6 +260,8 @@ function mapSimulation(simulation: BalanceSimulationResult): ScanBalanceSimulati
 			tokenId: approval.tokenId?.toString(),
 			scope: approval.scope,
 			approved: approval.approved,
+			symbol: approval.symbol,
+			decimals: approval.decimals,
 		})),
 		confidence: simulation.confidence,
 		notes: simulation.notes,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -159,6 +159,8 @@ const approvalChangeSchema = z
 		tokenId: z.string().optional(),
 		scope: z.enum(["token", "all"]).optional(),
 		approved: z.boolean().optional(),
+		symbol: z.string().optional(),
+		decimals: z.number().int().min(0).optional(),
 	})
 	.strict();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,9 @@ export interface ApprovalChange {
 	tokenId?: bigint;
 	scope?: "token" | "all";
 	approved?: boolean;
+	// Optional ERC-20 metadata (for human-readable display)
+	symbol?: string;
+	decimals?: number;
 }
 
 export interface BalanceSimulationResult {

--- a/test/simulation-e2e.test.ts
+++ b/test/simulation-e2e.test.ts
@@ -69,8 +69,8 @@ describe("simulation e2e", () => {
 		expect(output).toContain("Action:");
 		expect(output).toContain("Contract:");
 		expect(output).toContain("💰 BALANCE CHANGES");
-		expect(output).toContain("- 1 ETH");
-		expect(output).toContain("+ 1 WETH");
+		expect(output).toContain("You sent 1 ETH");
+		expect(output).toContain("You received 1 WETH");
 		expect(output).toContain("🔐 APPROVALS");
 		expect(output).toContain("📊 RISK:");
 		expect(output).not.toContain("Simulation pending");


### PR DESCRIPTION
Improves pre-sign UX readability:

- Adds a **CHECKS** section to the result box (verified/proxy/known protocol + top important findings)
- Balance changes now read like **“You sent … / You received …”**
- When simulation succeeds and looks swap-like, action becomes **“Swap X → Y”**
- Approvals become more readable (known spender names + token symbol/decimals when available)
- Adds 1inch router to known spenders

Also updates CLI tests for the new output.
