### PR TITLE
fix(proxy): keep Anvil warm + fast reset between simulations

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -11,6 +11,7 @@ import type {
 } from "./schema";
 import { simulateBalance } from "./simulations/balance";
 import { applySimulationVerdict, buildSimulationNotRun } from "./simulations/verdict";
+import type { TimingStore } from "./timing";
 import type {
 	AnalysisResult,
 	BalanceSimulationResult,
@@ -32,6 +33,7 @@ export interface ScanOptions {
 	config?: Config;
 	requestId?: string;
 	progress?: ScanProgress;
+	timings?: TimingStore;
 }
 
 const CHAIN_NAME_LOOKUP: Record<string, Chain> = {
@@ -88,6 +90,7 @@ export async function scanWithAnalysis(
 		chain,
 		options?.config,
 		options?.progress,
+		options?.timings,
 	);
 	const withSimulation = simulation ? { ...mergedAnalysis, simulation } : mergedAnalysis;
 	const finalAnalysis = applySimulationVerdict(normalizedInput, withSimulation);
@@ -206,6 +209,7 @@ async function runBalanceSimulation(
 	chain: Chain,
 	config: Config | undefined,
 	progress: ScanProgress | undefined,
+	timings: TimingStore | undefined,
 ): Promise<BalanceSimulationResult | undefined> {
 	if (!input.calldata) return undefined;
 
@@ -216,7 +220,7 @@ async function runBalanceSimulation(
 		return buildSimulationNotRun(input.calldata);
 	}
 
-	const result = await simulateBalance(input.calldata, chain, config);
+	const result = await simulateBalance(input.calldata, chain, config, timings);
 	progress?.({
 		provider: "Simulation",
 		status: result.success ? "success" : "error",

--- a/src/simulations/anvil-reset.ts
+++ b/src/simulations/anvil-reset.ts
@@ -1,0 +1,84 @@
+import { nowMs } from "../timing";
+
+export interface AnvilForkConfig {
+	forkUrl: string;
+	forkBlock?: number;
+}
+
+export interface AnvilResetClient {
+	snapshot: () => Promise<unknown>;
+	revert: (args: { id: string }) => Promise<unknown>;
+	request: (args: { method: string; params?: unknown[] }) => Promise<unknown>;
+}
+
+export interface WarmResetResult {
+	baselineSnapshotId: string;
+	usedAnvilReset: boolean;
+	ms: number;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+async function takeSnapshot(client: AnvilResetClient): Promise<string> {
+	const value = await client.snapshot();
+	if (!isNonEmptyString(value)) {
+		throw new Error("Anvil snapshot returned invalid id");
+	}
+	return value;
+}
+
+async function revertToSnapshot(client: AnvilResetClient, id: string): Promise<void> {
+	const result = await client.revert({ id });
+	if (typeof result === "boolean" && result === false) {
+		throw new Error("Anvil revert failed");
+	}
+}
+
+async function anvilReset(client: AnvilResetClient, fork: AnvilForkConfig): Promise<void> {
+	const forking: Record<string, unknown> = {
+		jsonRpcUrl: fork.forkUrl,
+	};
+	if (typeof fork.forkBlock === "number" && Number.isFinite(fork.forkBlock)) {
+		forking.blockNumber = Math.trunc(fork.forkBlock);
+	}
+	await client.request({
+		method: "anvil_reset",
+		params: [{ forking }],
+	});
+}
+
+export async function warmResetAnvilFork(options: {
+	client: AnvilResetClient;
+	fork: AnvilForkConfig;
+	baselineSnapshotId: string | null;
+}): Promise<WarmResetResult> {
+	const started = nowMs();
+	const client = options.client;
+	const fork = options.fork;
+
+	if (!options.baselineSnapshotId) {
+		const baselineSnapshotId = await takeSnapshot(client);
+		return {
+			baselineSnapshotId,
+			usedAnvilReset: false,
+			ms: nowMs() - started,
+		};
+	}
+
+	let usedAnvilReset = false;
+	try {
+		await revertToSnapshot(client, options.baselineSnapshotId);
+	} catch {
+		usedAnvilReset = true;
+		await anvilReset(client, fork);
+	}
+
+	const baselineSnapshotId = await takeSnapshot(client);
+	return {
+		baselineSnapshotId,
+		usedAnvilReset,
+		ms: nowMs() - started,
+	};
+}

--- a/src/timing.ts
+++ b/src/timing.ts
@@ -1,0 +1,38 @@
+import { performance } from "node:perf_hooks";
+
+export function nowMs(): number {
+	return performance.now();
+}
+
+export class TimingStore {
+	readonly #values = new Map<string, number[]>();
+
+	add(name: string, ms: number): void {
+		if (!Number.isFinite(ms)) return;
+		const existing = this.#values.get(name);
+		if (existing) {
+			existing.push(ms);
+			return;
+		}
+		this.#values.set(name, [ms]);
+	}
+
+	getTotals(): Array<{ name: string; ms: number; count: number }> {
+		const out: Array<{ name: string; ms: number; count: number }> = [];
+		for (const [name, values] of this.#values.entries()) {
+			const total = values.reduce((acc, value) => acc + value, 0);
+			out.push({ name, ms: total, count: values.length });
+		}
+		out.sort((a, b) => b.ms - a.ms);
+		return out;
+	}
+
+	toLogLine(prefix = "timing"): string {
+		const parts: string[] = [];
+		for (const entry of this.getTotals()) {
+			const rounded = Math.round(entry.ms);
+			parts.push(`${entry.name}=${rounded}ms${entry.count > 1 ? `x${entry.count}` : ""}`);
+		}
+		return parts.length > 0 ? `${prefix}: ${parts.join(" ")}` : `${prefix}: (none)`;
+	}
+}

--- a/test/anvil-reset.unit.test.ts
+++ b/test/anvil-reset.unit.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { warmResetAnvilFork } from "../src/simulations/anvil-reset";
+
+function createClient(options?: {
+	snapshotIds?: string[];
+	revertBehavior?: "ok" | "false" | "throw";
+}) {
+	const snapshotIds = options?.snapshotIds ?? ["0x1", "0x2", "0x3"];
+	let snapshotIndex = 0;
+	const calls: Array<{ method: string; params?: unknown[] }> = [];
+
+	return {
+		client: {
+			snapshot: async () => {
+				const value = snapshotIds[snapshotIndex] ?? `0x${snapshotIndex + 1}`;
+				snapshotIndex += 1;
+				return value;
+			},
+			revert: async (_args: { id: string }) => {
+				if (options?.revertBehavior === "throw") {
+					throw new Error("revert failed");
+				}
+				if (options?.revertBehavior === "false") {
+					return false;
+				}
+				return true;
+			},
+			request: async (args: { method: string; params?: unknown[] }) => {
+				calls.push({ method: args.method, params: args.params });
+				return null;
+			},
+		},
+		calls,
+	};
+}
+
+describe("warmResetAnvilFork", () => {
+	test("baseline null: takes a snapshot", async () => {
+		const { client, calls } = createClient();
+		const result = await warmResetAnvilFork({
+			client,
+			fork: { forkUrl: "http://example.invalid" },
+			baselineSnapshotId: null,
+		});
+		expect(result.usedAnvilReset).toBe(false);
+		expect(result.baselineSnapshotId).toBe("0x1");
+		expect(calls).toEqual([]);
+	});
+
+	test("baseline set + revert ok: reverts then snapshots", async () => {
+		const { client, calls } = createClient({
+			snapshotIds: ["0xaaa", "0xbbb"],
+			revertBehavior: "ok",
+		});
+		const result = await warmResetAnvilFork({
+			client,
+			fork: { forkUrl: "http://example.invalid" },
+			baselineSnapshotId: "0xdead",
+		});
+		expect(result.usedAnvilReset).toBe(false);
+		expect(result.baselineSnapshotId).toBe("0xaaa");
+		expect(calls).toEqual([]);
+	});
+
+	test("revert returns false: falls back to anvil_reset", async () => {
+		const { client, calls } = createClient({ snapshotIds: ["0x10"], revertBehavior: "false" });
+		const result = await warmResetAnvilFork({
+			client,
+			fork: { forkUrl: "http://rpc.local", forkBlock: 123 },
+			baselineSnapshotId: "0xdead",
+		});
+		expect(result.usedAnvilReset).toBe(true);
+		expect(result.baselineSnapshotId).toBe("0x10");
+		expect(calls.length).toBe(1);
+		expect(calls[0]?.method).toBe("anvil_reset");
+		const params = calls[0]?.params;
+		expect(Array.isArray(params)).toBe(true);
+		const first = Array.isArray(params) ? params[0] : null;
+		expect(first).toEqual({
+			forking: {
+				jsonRpcUrl: "http://rpc.local",
+				blockNumber: 123,
+			},
+		});
+	});
+});


### PR DESCRIPTION
Goal: reduce JSON-RPC proxy latency (Rabby ~5s timeout) by keeping a warm Anvil fork and resetting state per intercepted tx.

What changed:
- Add `TimingStore` + per-tx timing log line in proxy (incl. provider timings via progress events).
- Keep a long-lived Anvil instance and reset fork state between simulations via snapshot/revert (with `anvil_reset` fallback) (`warmResetAnvilFork`).
- Serialize simulations per warm Anvil instance (`runExclusive`) to avoid cross-request state contamination.
- Default simulation fork RPC to the proxy upstream URL (unless explicitly configured), to reduce fork latency variance.

Tests:
- `bun run check`
- `bun test`

Follow-ups:
- Rabby smoke test against real wallet traffic and capture before/after timing lines.