### PR TITLE
Two-tier CI: gate live/fork tests + nightly comprehensive workflow

### DIFF
--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -1,0 +1,33 @@
+name: CI (comprehensive)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      RUGSCAN_LIVE_TESTS: "1"
+      RUGSCAN_FORK_E2E: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+          cache: true
+
+      - name: Install Foundry (anvil)
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - run: bun install --frozen-lockfile
+      - run: bun run check
+      - run: bun test

--- a/README.md
+++ b/README.md
@@ -271,12 +271,25 @@ When `--ai` is enabled, rugscan sends contract data to an LLM for deeper analysi
 
 ## Development
 
+GitHub Actions runs two tiers of CI:
+- **Tier 1 (PR gating)**: default `bun test` (skips live-network + fork/anvil e2e suites)
+- **Tier 2 (comprehensive)**: enables live-network + fork/anvil e2e suites
+
 ```bash
 # Install deps
 bun install
 
-# Run tests
+# Tier 1 (default): fast + deterministic (no live-network or fork e2e tests)
 bun test
+
+# Tier 2 (optional): run tests that hit live provider APIs (Sourcify/GoPlus/DeFiLlama/etc)
+RUGSCAN_LIVE_TESTS=1 bun test
+
+# Tier 2 (optional): run fork/anvil e2e suites (requires Foundry's `anvil`)
+RUGSCAN_FORK_E2E=1 bun test
+
+# Run everything
+RUGSCAN_LIVE_TESTS=1 RUGSCAN_FORK_E2E=1 bun test
 
 # Build
 bun run build

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { analyze } from "../src/analyzer";
+
+const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 /**
  * rugscan analyzer tests

--- a/test/approvals-fixture-e2e.test.ts
+++ b/test/approvals-fixture-e2e.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
+
+const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 async function runCli(args: string[], envOverrides: Record<string, string | undefined> = {}) {
 	const env = { ...process.env, ...envOverrides };

--- a/test/providers/defillama.test.ts
+++ b/test/providers/defillama.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { matchProtocol } from "../../src/providers/defillama";
+
+const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("defillama", () => {
 	test("matchProtocol identifies Uniswap", async () => {

--- a/test/providers/goplus.test.ts
+++ b/test/providers/goplus.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { getTokenSecurity } from "../../src/providers/goplus";
+
+const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("goplus", () => {
 	test("getTokenSecurity flags honeypot tokens", async () => {

--- a/test/providers/proxy.test.ts
+++ b/test/providers/proxy.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { detectProxy } from "../../src/providers/proxy";
+
+const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("proxy detection", () => {
 	test("detectProxy identifies EIP-1967 proxies (USDC)", async () => {

--- a/test/providers/sourcify.test.ts
+++ b/test/providers/sourcify.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { checkVerification } from "../../src/providers/sourcify";
+
+const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("sourcify", () => {
 	test("checkVerification returns verified contract metadata", async () => {

--- a/test/scan-cli.test.ts
+++ b/test/scan-cli.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
+
+const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 async function runCli(args: string[], envOverrides: Record<string, string | undefined> = {}) {
 	const env = { ...process.env, ...envOverrides };

--- a/test/simulation-e2e.test.ts
+++ b/test/simulation-e2e.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 async function runCli(args: string[], envOverrides: Record<string, string | undefined> = {}) {
 	const env = { ...process.env, ...envOverrides };

--- a/test/simulation-lend-borrow-fixtures-e2e.test.ts
+++ b/test/simulation-lend-borrow-fixtures-e2e.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;

--- a/test/simulation-router-swap-fixtures-e2e.test.ts
+++ b/test/simulation-router-swap-fixtures-e2e.test.ts
@@ -20,6 +20,7 @@ function isSimulationResult(value: unknown): value is Record<string, unknown> {
 const fixturesDir = fileURLToPath(new URL("./fixtures/txs", import.meta.url));
 const anvilPath =
 	process.env.RUGSCAN_ANVIL_PATH ?? path.join(os.homedir(), ".foundry", "bin", "anvil");
+const forkE2E = process.env.RUGSCAN_FORK_E2E === "1";
 
 const fixtureFiles = readdirSync(fixturesDir)
 	.filter((file) => file.endsWith(".json"))
@@ -40,7 +41,7 @@ async function loadFixture(fileName: string): Promise<TxFixture> {
 
 describe("router swap fixtures e2e", () => {
 	for (const fileName of fixtureFiles) {
-		const runner = existsSync(anvilPath) ? test : test.skip;
+		const runner = forkE2E && existsSync(anvilPath) ? test : test.skip;
 		runner(
 			`${fileName} simulates successfully`,
 			async () => {

--- a/test/simulation-universalrouter-fixture-e2e.test.ts
+++ b/test/simulation-universalrouter-fixture-e2e.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { test as bunTest, describe, expect } from "bun:test";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;


### PR DESCRIPTION
## Summary

This splits CI into two tiers:

- **Tier 1 (PR gating)**: fast/deterministic by default (`bun test`), skips tests that hit live provider APIs and fork/anvil E2E suites.
- **Tier 2 (comprehensive)**: new scheduled + manual workflow that runs the live-network provider/analyzer/CLI tests and the fork/anvil E2E suites.

## How it works

- Live-network tests are gated behind `RUGSCAN_LIVE_TESTS=1`.
- Fork/anvil E2E tests are gated behind `RUGSCAN_FORK_E2E=1` (and still check for anvil).

## CI changes

- Existing `.github/workflows/ci.yml` remains PR-gating.
- Added `.github/workflows/ci-comprehensive.yml` (nightly + `workflow_dispatch`) which sets:
  - `RUGSCAN_LIVE_TESTS=1`
  - `RUGSCAN_FORK_E2E=1`
  - installs Foundry (anvil) via `foundry-rs/foundry-toolchain`.

## Local

See README `Development` section for running Tier 2 locally.

## Verification

- `bun run check`
- `bun test` (Tier 1)