### PR TITLE
docs: update README for scan/proxy workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ Pre-transaction security analysis for EVM contracts. Know what you're signing be
 
 ## Install
 
+> Note: rugscan is not published to npm yet.
+
+For now, run from source:
+
 ```bash
-bun add rugscan
+git clone https://github.com/marcomariscal/rugscan
+cd rugscan
+bun install
+
+# examples below use `rugscan ...`; when running from source, replace with:
+# bun run src/cli/index.ts ...
 ```
 
 ## Quick Start
@@ -63,6 +72,7 @@ Flags:
   - `-` to read from stdin
 - `--to/--from/--value` — when `--calldata` is raw hex (or when providing tx fields directly)
 - `--no-sim` — disable Anvil simulation
+  - By default, rugscan will try to run an **Anvil fork simulation** for transaction inputs. Simulation success + decoded intent is the primary signal when available.
 - `--fail-on <caution|warning|danger>` — set exit threshold (default: `warning`)
 - `--output <path|->` (default: `-`)
 - `--quiet` — suppress progress/logging
@@ -126,11 +136,11 @@ Notes:
 ╰─────────────────────────────────────────────────────────────────╯
 ```
 
-**Exit codes:**
+**Exit codes (not a guarantee):**
 - `rugscan analyze` / `rugscan approval`:
-  - `0` — OK (safe to interact)
-  - `1` — CAUTION/WARNING (proceed with awareness)
-  - `2` — DANGER (high risk)
+  - `0` — OK per configured checks (no findings at/above the built-in thresholds)
+  - `1` — CAUTION/WARNING
+  - `2` — DANGER
 - `rugscan scan`:
   - `0` — recommendation is below `--fail-on`
   - `2` — recommendation is >= `--fail-on` (default: `warning`)


### PR DESCRIPTION
Docs-only update to README.md:

- Documented `rugscan scan` flags (`--format json|sarif` default is text, `--calldata` forms incl `@file`/stdin, `--to/--from/--value`, `--no-sim`, `--fail-on`, `--output`, `--quiet`) + examples.
- Clarified exit code semantics for `scan` (uses `--fail-on` threshold) vs `analyze`/`approval`.
- Added `rugscan proxy` workflow notes (`--wallet` fast mode, `--record-dir` recording bundles) and clarified allowlist v1 error details (`error.data.*`).
- Expanded CI/test docs to mention `.github/workflows/ci-comprehensive.yml` (nightly/manual) and the env vars it sets.

Checks:
- `bun run check`
- `bun test`