### PR TITLE
feat: stable JSON output v1 for scan

### DIFF
--- a/docs/stable-json-output-v1.md
+++ b/docs/stable-json-output-v1.md
@@ -1,0 +1,60 @@
+# Stable JSON Output v1 (`rugscan scan --format json`)
+
+This document defines a **stable, versioned** JSON contract intended for programmatic integrations (SDK/MCP/CI) consuming rugscan scan output.
+
+Applies to:
+- `rugscan scan --format json`
+- the local server endpoint `POST /v1/scan`
+
+## Contract
+
+All v1 payloads MUST include a top-level version:
+
+- `schemaVersion: 1`
+
+```json
+{
+  "schemaVersion": 1,
+  "requestId": "<uuid>",
+  "scan": { "...": "..." }
+}
+```
+
+### Required fields (guaranteed)
+
+Top-level:
+- `schemaVersion` — always the literal number `1`.
+- `requestId` — UUID string generated per scan.
+- `scan` — scan result object.
+
+`scan`:
+- `scan.input` — exactly one of:
+  - `{ "address": "0x…" }`, OR
+  - `{ "calldata": { "to": "0x…", "data": "0x…", ... } }`
+- `scan.recommendation` — one of `"ok" | "caution" | "warning" | "danger"`.
+- `scan.confidence` — number in `[0, 1]`.
+- `scan.findings` — array (may be empty). Each finding includes:
+  - `code` (string)
+  - `severity` (`"ok" | "caution" | "warning" | "danger"`)
+  - `message` (string)
+- `scan.contract` — always present.
+  - `scan.contract.address` is always present.
+
+### Best-effort fields (may be missing)
+
+These may be omitted depending on provider availability, configuration, or scan mode:
+
+- `scan.intent` — human-readable intent summary (when calldata decoding succeeds).
+- `scan.contract.*` metadata:
+  - `chain`, `isContract`, `name`, `symbol`, `isProxy`, `implementation`, `verifiedSource`, `tags`
+- `scan.simulation` — simulation result (may be omitted when disabled via `--no-sim`, unsupported, or unavailable).
+
+## Non-goals
+
+- AI output is optional and **not part of this stable scan JSON contract**.
+- Providers may be skipped/time out; missing best-effort fields should not be treated as an error.
+- This contract does not promise determinism for values derived from live upstream sources.
+
+## Implementation note
+
+The v1 contract is represented in TypeScript + Zod in `src/schema.ts`.

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,13 +1,14 @@
 import { type AnalyzeOptions, analyze, determineRecommendation } from "./analyzer";
 import { analyzeCalldata } from "./analyzers/calldata";
 import { buildIntent } from "./intent";
-import type {
-	AnalyzeResponse,
-	ContractInfo,
-	BalanceSimulationResult as ScanBalanceSimulationResult,
-	ScanFinding,
-	ScanInput,
-	ScanResult,
+import {
+	type AnalyzeResponse,
+	type ContractInfo,
+	RUGSCAN_SCHEMA_VERSION,
+	type BalanceSimulationResult as ScanBalanceSimulationResult,
+	type ScanFinding,
+	type ScanInput,
+	type ScanResult,
 } from "./schema";
 import { simulateBalance } from "./simulations/balance";
 import { applySimulationVerdict, buildSimulationNotRun } from "./simulations/verdict";
@@ -139,6 +140,7 @@ export function buildAnalyzeResponse(
 	requestId?: string,
 ): AnalyzeResponse {
 	return {
+		schemaVersion: RUGSCAN_SCHEMA_VERSION,
 		requestId: requestId ?? crypto.randomUUID(),
 		scan: buildScanResult(input, analysis),
 	};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { Recommendation as BaseRecommendation } from "./types";
 
+/**
+ * Stable JSON schema version for `rugscan scan --format json` and `POST /v1/scan`.
+ */
+export const RUGSCAN_SCHEMA_VERSION: 1 = 1;
+
 export type Recommendation = BaseRecommendation;
 
 export interface ScanFinding {
@@ -76,11 +81,12 @@ export interface ScanResult {
 	recommendation: Recommendation;
 	confidence: number;
 	findings: ScanFinding[];
-	contract?: ContractInfo;
+	contract: ContractInfo;
 	simulation?: BalanceSimulationResult;
 }
 
 export interface AnalyzeResponse {
+	schemaVersion: 1;
 	requestId: string;
 	scan: ScanResult;
 }
@@ -199,13 +205,14 @@ export const scanResultSchema = z
 		recommendation: recommendationSchema,
 		confidence: z.number().min(0).max(1),
 		findings: z.array(scanFindingSchema),
-		contract: contractInfoSchema.optional(),
+		contract: contractInfoSchema,
 		simulation: balanceSimulationSchema.optional(),
 	})
 	.strict();
 
 export const analyzeResponseSchema = z
 	.object({
+		schemaVersion: z.literal(RUGSCAN_SCHEMA_VERSION).optional().default(RUGSCAN_SCHEMA_VERSION),
 		requestId: z.string().uuid(),
 		scan: scanResultSchema,
 	})

--- a/test/fixtures/recordings/north-star__approve-unlimited-sim-not-run/analyzeResponse.json
+++ b/test/fixtures/recordings/north-star__approve-unlimited-sim-not-run/analyzeResponse.json
@@ -1,4 +1,5 @@
 {
+	"schemaVersion": 1,
 	"requestId": "33333333-3333-4333-8333-333333333333",
 	"scan": {
 		"input": {

--- a/test/fixtures/recordings/north-star__policy-unknown-spender/analyzeResponse.json
+++ b/test/fixtures/recordings/north-star__policy-unknown-spender/analyzeResponse.json
@@ -1,4 +1,5 @@
 {
+	"schemaVersion": 1,
 	"requestId": "44444444-4444-4444-8444-444444444444",
 	"scan": {
 		"input": {

--- a/test/fixtures/recordings/north-star__swap-sim-failed/analyzeResponse.json
+++ b/test/fixtures/recordings/north-star__swap-sim-failed/analyzeResponse.json
@@ -1,4 +1,5 @@
 {
+	"schemaVersion": 1,
 	"requestId": "22222222-2222-4222-8222-222222222222",
 	"scan": {
 		"input": {

--- a/test/fixtures/recordings/north-star__swap-sim-ok/analyzeResponse.json
+++ b/test/fixtures/recordings/north-star__swap-sim-ok/analyzeResponse.json
@@ -1,4 +1,5 @@
 {
+	"schemaVersion": 1,
 	"requestId": "11111111-1111-4111-8111-111111111111",
 	"scan": {
 		"input": {

--- a/test/fixtures/scan-response.json
+++ b/test/fixtures/scan-response.json
@@ -1,4 +1,5 @@
 {
+	"schemaVersion": 1,
 	"requestId": "00000000-0000-4000-8000-000000000000",
 	"scan": {
 		"input": {

--- a/test/jsonrpc-proxy.integration.test.ts
+++ b/test/jsonrpc-proxy.integration.test.ts
@@ -301,6 +301,7 @@ describe("jsonrpc proxy - integration", () => {
 		const spender = "0x1111111111111111111111111111111111111111";
 
 		const response: AnalyzeResponse = {
+			schemaVersion: 1,
 			requestId: "00000000-0000-0000-0000-000000000000",
 			scan: {
 				input: {
@@ -315,6 +316,11 @@ describe("jsonrpc proxy - integration", () => {
 				recommendation: "ok",
 				confidence: 1,
 				findings: [],
+				contract: {
+					address: token,
+					chain: "ethereum",
+					isContract: true,
+				},
 				simulation: {
 					success: true,
 					assetChanges: [],
@@ -429,6 +435,7 @@ describe("jsonrpc proxy - integration", () => {
 		const spender = "0x3333333333333333333333333333333333333333";
 
 		const response: AnalyzeResponse = {
+			schemaVersion: 1,
 			requestId: "00000000-0000-0000-0000-000000000000",
 			scan: {
 				input: {
@@ -453,6 +460,11 @@ describe("jsonrpc proxy - integration", () => {
 						},
 					},
 				],
+				contract: {
+					address: token,
+					chain: "ethereum",
+					isContract: true,
+				},
 				simulation: {
 					success: true,
 					assetChanges: [],

--- a/test/jsonrpc-proxy.recording.test.ts
+++ b/test/jsonrpc-proxy.recording.test.ts
@@ -48,6 +48,7 @@ describe("jsonrpc proxy - recording", () => {
 				recommendation: "ok",
 				simulationSuccess: true,
 				response: {
+					schemaVersion: 1,
 					requestId: crypto.randomUUID(),
 					scan: {
 						input,

--- a/test/north-star-ux.contract.test.ts
+++ b/test/north-star-ux.contract.test.ts
@@ -199,6 +199,7 @@ function isRenderContext(value: unknown): value is RenderContext {
 
 function isAnalyzeResponse(value: unknown): value is AnalyzeResponse {
 	if (!isRecord(value)) return false;
+	if (value.schemaVersion !== 1) return false;
 	if (typeof value.requestId !== "string") return false;
 	if (!isRecord(value.scan)) return false;
 	return true;

--- a/test/scan-cli.test.ts
+++ b/test/scan-cli.test.ts
@@ -27,6 +27,7 @@ describe("cli scan", () => {
 
 		expect(result.exitCode).toBe(0);
 		const parsed = JSON.parse(result.stdout);
+		expect(parsed.schemaVersion).toBe(1);
 		expect(parsed.requestId).toBeDefined();
 		expect(parsed.scan?.input?.address).toBeDefined();
 		expect(parsed.scan?.recommendation).toBeDefined();

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { buildAnalyzeResponse } from "../src/scan";
 import { analyzeResponseSchema, scanInputSchema } from "../src/schema";
+import type { AnalysisResult } from "../src/types";
 
 describe("schema", () => {
 	const address = "0x1111111111111111111111111111111111111111";
@@ -54,5 +56,29 @@ describe("schema", () => {
 		};
 		const result = analyzeResponseSchema.safeParse(response);
 		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.schemaVersion).toBe(1);
+		}
+	});
+
+	test("AnalyzeResponse JSON output includes schemaVersion=1", () => {
+		const requestId = "00000000-0000-4000-8000-000000000000";
+		const address = "0x1111111111111111111111111111111111111111";
+
+		const analysis: AnalysisResult = {
+			contract: {
+				address,
+				chain: "ethereum",
+				verified: true,
+				is_proxy: false,
+			},
+			findings: [],
+			confidence: { level: "high", reasons: [] },
+			recommendation: "ok",
+		};
+
+		const response = buildAnalyzeResponse({ address }, analysis, requestId);
+		const parsed = JSON.parse(JSON.stringify(response));
+		expect(parsed.schemaVersion).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary

Adds a stable, versioned JSON contract for `rugscan scan --format json` (and the local server `POST /v1/scan`).

- Emits top-level `schemaVersion: 1`
- Documents required vs best-effort fields

## Contract (v1)

Top-level keys:
- `schemaVersion: 1` (required)
- `requestId: string` (uuid)
- `scan: { ... }`

Guaranteed inside `scan`:
- `input` (exactly one of `address` or `calldata`)
- `recommendation`, `confidence`, `findings` (array)
- `contract` (always present; `contract.address` always present)

Best-effort:
- `scan.intent`
- `scan.contract.*` metadata (name, tags, proxy fields, verification)
- `scan.simulation`

Non-goals:
- AI output is optional and not part of the stable scan JSON contract.
- Live upstream/provider-derived values may vary; providers may be skipped/time out.

See: `docs/stable-json-output-v1.md`.

## Implementation

- Updates `src/schema.ts` types + Zod schemas:
  - `AnalyzeResponse.schemaVersion: 1`
  - `ScanResult.contract` is required
  - `analyzeResponseSchema` accepts missing `schemaVersion` but defaults it to `1` for backwards-compat parsing.
- Updates `buildAnalyzeResponse` to always emit `schemaVersion: 1`.
- Updates fixtures/tests expecting JSON output.

## Tests

- Adds a deterministic unit test asserting `schemaVersion === 1` in JSON output.
- Ran:
  - `bun run check`
  - `bun test`

## Notes on compatibility

- JSON output changes are additive (`schemaVersion` added).
- Type/Zod schema now requires `scan.contract`; responses missing `contract` will fail validation (the CLI/server emit it).
