### PR TITLE
feat: MCP stdio server

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ rugscan analyze <address> [options]
 rugscan scan [address] [options]
 rugscan approval --token <address> --spender <address> --amount <value> [--expected <address>] [--chain <chain>]
 rugscan proxy [options]
+rugscan mcp
 ```
 
 ### `rugscan scan`
@@ -109,6 +110,18 @@ Notes:
 - `--ai` Enable AI risk analysis (requires API key)
 - `--model` Override AI model or force provider (e.g. `openai:gpt-4o`)
 - `--token/--spender/--amount/--expected` Approval analysis inputs
+
+### MCP
+
+Run an MCP server over stdio:
+
+```bash
+rugscan mcp
+```
+
+Tools exposed:
+- `rugscan.analyzeTransaction`
+- `rugscan.analyzeAddress`
 
 ## Output
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { analyzeApproval } from "../approval";
 import { loadConfig, saveRpcUrl } from "../config";
 import { MAX_UINT256 } from "../constants";
 import { createJsonRpcProxyServer } from "../jsonrpc/proxy";
+import { runMcpServer } from "../mcp/server";
 import { resolveProvider } from "../providers/ai";
 import { resolveScanChain, scanWithAnalysis } from "../scan";
 import { type CalldataInput, type ScanInput, scanInputSchema } from "../schema";
@@ -33,6 +34,7 @@ Usage:
   rugscan scan [address] [--format json|sarif] [--calldata <json|hex|@file|->] [--to <address>] [--from <address>] [--value <value>] [--fail-on <caution|warning|danger>]
   rugscan approval --token <address> --spender <address> --amount <value> [--expected <address>] [--chain <chain>]
   rugscan proxy [--upstream <rpc-url>] [--save] [--port <port>] [--hostname <host>] [--chain <chain>] [--threshold <caution|warning|danger>] [--on-risk <block|prompt>] [--record-dir <path>] [--wallet] [--once]
+  rugscan mcp
 
 Options:
   --chain, -c    Chain to analyze on (default: ethereum)
@@ -120,6 +122,10 @@ async function main() {
 	}
 	if (command === "proxy") {
 		await runProxy(args.slice(1));
+		return;
+	}
+	if (command === "mcp") {
+		await runMcp(args.slice(1));
 		return;
 	}
 
@@ -467,6 +473,17 @@ async function runProxy(args: string[]) {
 
 	// Keep process alive.
 	await new Promise(() => {});
+}
+
+async function runMcp(args: string[]) {
+	if (args.includes("--help") || args.includes("-h")) {
+		console.log(
+			"rugscan mcp - MCP server over stdio (Model Context Protocol)\n\nUsage:\n  rugscan mcp\n\nNotes:\n  - Communicates over stdin/stdout using JSON-RPC framing (Content-Length).\n  - Exposes Rugscan analysis as MCP tools.\n",
+		);
+		process.exit(0);
+	}
+
+	await runMcpServer();
 }
 
 function parseChain(args: string[]): Chain {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,371 @@
+import { z } from "zod";
+import type { AnalyzerDeps } from "../analyzer";
+import { renderHeading, renderResultBox } from "../cli/ui";
+import { loadConfig } from "../config";
+import { scanWithAnalysis } from "../scan";
+import { scanInputSchema } from "../schema";
+import type { AnalysisResult, Chain, Config } from "../types";
+import { encodeStdioMessage, runStdioJsonRpcServer } from "./stdio";
+
+type JsonRpcId = string | number | null;
+
+type JsonRpcRequest = {
+	jsonrpc: "2.0";
+	id?: JsonRpcId;
+	method: string;
+	params?: unknown;
+};
+
+type JsonRpcSuccess = {
+	jsonrpc: "2.0";
+	id: JsonRpcId;
+	result: unknown;
+};
+
+type JsonRpcFailure = {
+	jsonrpc: "2.0";
+	id: JsonRpcId;
+	error: { code: number; message: string; data?: unknown };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function isJsonRpcRequest(value: unknown): value is JsonRpcRequest {
+	if (!isRecord(value)) return false;
+	if (value.jsonrpc !== "2.0") return false;
+	if (typeof value.method !== "string") return false;
+	if ("id" in value) {
+		const id = value.id;
+		if (id !== null && typeof id !== "string" && typeof id !== "number") return false;
+	}
+	return true;
+}
+
+function jsonRpcError(
+	id: JsonRpcId,
+	code: number,
+	message: string,
+	data?: unknown,
+): JsonRpcFailure {
+	return {
+		jsonrpc: "2.0",
+		id,
+		error: {
+			code,
+			message,
+			...(data === undefined ? {} : { data }),
+		},
+	};
+}
+
+function jsonRpcResult(id: JsonRpcId, result: unknown): JsonRpcSuccess {
+	return { jsonrpc: "2.0", id, result };
+}
+
+const analyzeTransactionArgsSchema = z
+	.object({
+		chain: z.string().min(1),
+		to: z.string().min(1),
+		data: z.string().min(1),
+		from: z.string().optional(),
+		value: z.string().optional(),
+		noSim: z.boolean().optional(),
+		walletMode: z.boolean().optional(),
+	})
+	.strict();
+
+const analyzeAddressArgsSchema = z
+	.object({
+		chain: z.string().min(1),
+		address: z.string().min(1),
+		walletMode: z.boolean().optional(),
+	})
+	.strict();
+
+function resolveStubDepsFromEnv(): AnalyzerDeps | null {
+	if (process.env.RUGSCAN_MCP_STUB_DEPS !== "1") return null;
+
+	return {
+		ai: {
+			analyzeRisk: async () => ({
+				analysis: {
+					risk_score: 0,
+					summary: "stub",
+					concerns: [],
+					model: "stub",
+					provider: "openai",
+				},
+			}),
+		},
+		defillama: {
+			matchProtocol: async () => null,
+		},
+		etherscan: {
+			getAddressLabels: async () => null,
+			getContractData: async () => null,
+		},
+		goplus: {
+			getTokenSecurity: async () => ({ data: null }),
+		},
+		proxy: {
+			isContract: async () => true,
+			detectProxy: async () => ({ is_proxy: false }),
+		},
+		sourcify: {
+			checkVerification: async () => ({ verified: false }),
+		},
+	};
+}
+
+function toolList() {
+	return [
+		{
+			name: "rugscan.analyzeTransaction",
+			description: "Analyze an EVM transaction target + calldata for risk findings.",
+			inputSchema: {
+				type: "object",
+				additionalProperties: false,
+				properties: {
+					chain: { type: "string", description: "Chain name or chain id (ex: ethereum, 1)." },
+					to: { type: "string", description: "Target contract address (0x...)." },
+					data: { type: "string", description: "Hex calldata (0x...)." },
+					from: { type: "string", description: "Optional sender address (0x...)." },
+					value: { type: "string", description: "Optional value (decimal or 0x)." },
+					noSim: { type: "boolean", description: "Disable transaction simulation." },
+					walletMode: {
+						type: "boolean",
+						description: "Wallet fast mode (tight provider budgets).",
+					},
+				},
+				required: ["chain", "to", "data"],
+			},
+		},
+		{
+			name: "rugscan.analyzeAddress",
+			description: "Analyze a contract/address for risk findings.",
+			inputSchema: {
+				type: "object",
+				additionalProperties: false,
+				properties: {
+					chain: { type: "string", description: "Chain name or chain id (ex: ethereum, 1)." },
+					address: { type: "string", description: "Contract/address (0x...)." },
+					walletMode: {
+						type: "boolean",
+						description: "Wallet fast mode (tight provider budgets).",
+					},
+				},
+				required: ["chain", "address"],
+			},
+		},
+	];
+}
+
+function resolveChain(value: string): Chain {
+	const normalized = value.toLowerCase();
+	if (normalized === "ethereum" || normalized === "1") return "ethereum";
+	if (normalized === "base" || normalized === "8453") return "base";
+	if (normalized === "arbitrum" || normalized === "42161") return "arbitrum";
+	if (normalized === "optimism" || normalized === "10") return "optimism";
+	if (normalized === "polygon" || normalized === "137") return "polygon";
+	throw new Error(`Invalid chain: ${value}`);
+}
+
+function configWithNoSim(config: Config, noSim: boolean | undefined): Config {
+	if (!noSim) return config;
+	return {
+		...config,
+		simulation: {
+			...config.simulation,
+			enabled: false,
+		},
+	};
+}
+
+function buildRenderedText(options: {
+	chain: Chain;
+	analysis: AnalysisResult;
+	sender?: string;
+}): string {
+	const heading = renderHeading(`Tx scan on ${options.chain}`);
+	const body = renderResultBox(options.analysis, {
+		hasCalldata: true,
+		sender: options.sender,
+	});
+	return `${heading}\n\n${body}\n`;
+}
+
+export async function runMcpServer(): Promise<void> {
+	const config = await loadConfig();
+	const stubDeps = resolveStubDepsFromEnv();
+
+	await runStdioJsonRpcServer({
+		onMessage: async (message) => {
+			if (!isJsonRpcRequest(message)) return;
+
+			const id = "id" in message ? (message.id ?? null) : null;
+			const method = message.method;
+
+			try {
+				if (method === "initialize") {
+					const result = {
+						protocolVersion: "2024-11-05",
+						capabilities: { tools: {} },
+						serverInfo: { name: "rugscan", version: "0.1.0" },
+					};
+					process.stdout.write(encodeStdioMessage(jsonRpcResult(id, result)));
+					return;
+				}
+
+				if (method === "tools/list") {
+					process.stdout.write(
+						encodeStdioMessage(
+							jsonRpcResult(id, {
+								tools: toolList(),
+							}),
+						),
+					);
+					return;
+				}
+
+				if (method === "tools/call") {
+					if (!isRecord(message.params)) {
+						process.stdout.write(encodeStdioMessage(jsonRpcError(id, -32602, "Invalid params")));
+						return;
+					}
+
+					const name = message.params.name;
+					if (typeof name !== "string") {
+						process.stdout.write(encodeStdioMessage(jsonRpcError(id, -32602, "Missing tool name")));
+						return;
+					}
+
+					const args = message.params.arguments;
+
+					if (name === "rugscan.analyzeTransaction") {
+						const parsed = analyzeTransactionArgsSchema.safeParse(args);
+						if (!parsed.success) {
+							process.stdout.write(
+								encodeStdioMessage(jsonRpcError(id, -32602, "Invalid tool arguments")),
+							);
+							return;
+						}
+
+						const chain = resolveChain(parsed.data.chain);
+						const input = {
+							calldata: {
+								to: parsed.data.to,
+								from: parsed.data.from,
+								data: parsed.data.data,
+								value: parsed.data.value,
+								chain: parsed.data.chain,
+							},
+						};
+						const validated = scanInputSchema.safeParse(input);
+						if (!validated.success || !validated.data.calldata) {
+							process.stdout.write(
+								encodeStdioMessage(jsonRpcError(id, -32602, "Invalid transaction input")),
+							);
+							return;
+						}
+
+						const nextConfig = configWithNoSim(config, parsed.data.noSim);
+						const analyzeOptions = {
+							mode: parsed.data.walletMode ? "wallet" : "default",
+							deps: stubDeps ?? undefined,
+						};
+						const depsEnabled = analyzeOptions.deps !== undefined;
+						const options = depsEnabled
+							? { chain: String(chain), config: nextConfig, analyzeOptions }
+							: {
+									chain: String(chain),
+									config: nextConfig,
+									analyzeOptions: { mode: analyzeOptions.mode },
+								};
+
+						const { analysis, response } = await scanWithAnalysis(validated.data, options);
+						const renderedText = buildRenderedText({
+							chain,
+							analysis,
+							sender: response.scan.input.calldata?.from,
+						});
+
+						process.stdout.write(
+							encodeStdioMessage(
+								jsonRpcResult(id, {
+									content: [
+										{ type: "text", text: renderedText },
+										{ type: "text", text: JSON.stringify(response, null, 2) },
+									],
+								}),
+							),
+						);
+						return;
+					}
+
+					if (name === "rugscan.analyzeAddress") {
+						const parsed = analyzeAddressArgsSchema.safeParse(args);
+						if (!parsed.success) {
+							process.stdout.write(
+								encodeStdioMessage(jsonRpcError(id, -32602, "Invalid tool arguments")),
+							);
+							return;
+						}
+
+						const chain = resolveChain(parsed.data.chain);
+						const input = { address: parsed.data.address };
+						const validated = scanInputSchema.safeParse(input);
+						if (!validated.success || !validated.data.address) {
+							process.stdout.write(
+								encodeStdioMessage(jsonRpcError(id, -32602, "Invalid address input")),
+							);
+							return;
+						}
+
+						const analyzeOptions = {
+							mode: parsed.data.walletMode ? "wallet" : "default",
+							deps: stubDeps ?? undefined,
+						};
+						const depsEnabled = analyzeOptions.deps !== undefined;
+						const options = depsEnabled
+							? { chain: String(chain), config, analyzeOptions }
+							: {
+									chain: String(chain),
+									config,
+									analyzeOptions: { mode: analyzeOptions.mode },
+								};
+
+						const { response } = await scanWithAnalysis(validated.data, options);
+						process.stdout.write(
+							encodeStdioMessage(
+								jsonRpcResult(id, {
+									content: [{ type: "text", text: JSON.stringify(response, null, 2) }],
+								}),
+							),
+						);
+						return;
+					}
+
+					process.stdout.write(
+						encodeStdioMessage(jsonRpcError(id, -32601, `Unknown tool: ${name}`)),
+					);
+					return;
+				}
+
+				if (id !== null) {
+					process.stdout.write(
+						encodeStdioMessage(jsonRpcError(id, -32601, `Method not found: ${method}`)),
+					);
+				}
+			} catch (error) {
+				const message = error instanceof Error ? error.message : "Internal error";
+				process.stdout.write(encodeStdioMessage(jsonRpcError(id, -32000, message)));
+			}
+		},
+		onParseError: (error) => {
+			const message = error instanceof Error ? error.message : String(error);
+			process.stderr.write(`rugscan mcp parse error: ${message}\n`);
+		},
+	});
+}

--- a/src/mcp/stdio.ts
+++ b/src/mcp/stdio.ts
@@ -1,0 +1,76 @@
+import { Buffer } from "node:buffer";
+
+export type StdioMessageHandler = (message: unknown) => Promise<void> | void;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function getContentLength(headers: string): number | null {
+	const lines = headers.split("\r\n");
+	for (const line of lines) {
+		const idx = line.indexOf(":");
+		if (idx === -1) continue;
+		const key = line.slice(0, idx).trim().toLowerCase();
+		if (key !== "content-length") continue;
+		const value = line.slice(idx + 1).trim();
+		const parsed = Number.parseInt(value, 10);
+		return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+	}
+	return null;
+}
+
+export function encodeStdioMessage(payload: unknown): Buffer {
+	const body = JSON.stringify(payload);
+	const length = Buffer.byteLength(body, "utf8");
+	const header = `Content-Length: ${length}\r\n\r\n`;
+	return Buffer.concat([Buffer.from(header, "utf8"), Buffer.from(body, "utf8")]);
+}
+
+export async function runStdioJsonRpcServer(options: {
+	onMessage: StdioMessageHandler;
+	onParseError?: (error: unknown) => void;
+}): Promise<void> {
+	let buffer = Buffer.alloc(0);
+
+	for await (const chunk of process.stdin) {
+		const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+		buffer = Buffer.concat([buffer, bytes]);
+
+		while (true) {
+			const headerEnd = buffer.indexOf("\r\n\r\n");
+			if (headerEnd === -1) break;
+
+			const headerRaw = buffer.slice(0, headerEnd).toString("utf8");
+			const contentLength = getContentLength(headerRaw);
+			if (contentLength === null) {
+				options.onParseError?.(new Error("Missing Content-Length header"));
+				// Discard up to headerEnd+4 to avoid infinite loop.
+				buffer = buffer.slice(headerEnd + 4);
+				continue;
+			}
+
+			const start = headerEnd + 4;
+			const end = start + contentLength;
+			if (buffer.length < end) break;
+
+			const body = buffer.slice(start, end).toString("utf8");
+			buffer = buffer.slice(end);
+
+			let message: unknown;
+			try {
+				message = JSON.parse(body);
+			} catch (error) {
+				options.onParseError?.(error);
+				continue;
+			}
+
+			if (!isRecord(message)) {
+				options.onParseError?.(new Error("JSON-RPC message must be an object"));
+				continue;
+			}
+
+			await options.onMessage(message);
+		}
+	}
+}

--- a/test/mcp.unit.test.ts
+++ b/test/mcp.unit.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+
+function encodeMessage(payload: unknown): Uint8Array {
+	const body = JSON.stringify(payload);
+	const header = `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n`;
+	return new Uint8Array(Buffer.concat([Buffer.from(header, "utf8"), Buffer.from(body, "utf8")]));
+}
+
+async function readMessage(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<unknown> {
+	let buffer = Buffer.alloc(0);
+
+	while (true) {
+		const headerEnd = buffer.indexOf("\r\n\r\n");
+		if (headerEnd !== -1) {
+			const headerRaw = buffer.slice(0, headerEnd).toString("utf8");
+			const match = headerRaw.match(/Content-Length:\s*(\d+)/i);
+			const length = match ? Number.parseInt(match[1] ?? "", 10) : NaN;
+			if (Number.isFinite(length)) {
+				const start = headerEnd + 4;
+				const end = start + length;
+				if (buffer.length >= end) {
+					const body = buffer.slice(start, end).toString("utf8");
+					const remaining = buffer.slice(end);
+					buffer = remaining;
+					return JSON.parse(body);
+				}
+			}
+		}
+
+		const next = await reader.read();
+		if (next.done) {
+			throw new Error("EOF while waiting for MCP message");
+		}
+		buffer = Buffer.concat([buffer, Buffer.from(next.value)]);
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function findAnalyzeResponseInToolResult(result: unknown): { schemaVersion: number } | null {
+	if (!isRecord(result)) return null;
+	const content = result.content;
+	if (!Array.isArray(content)) return null;
+
+	for (const item of content) {
+		if (!isRecord(item)) continue;
+		const text = item.text;
+		if (typeof text !== "string") continue;
+		const trimmed = text.trim();
+		if (!trimmed.startsWith("{")) continue;
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (!isRecord(parsed)) continue;
+			const schemaVersion = parsed.schemaVersion;
+			if (schemaVersion === 1) return { schemaVersion: 1 };
+		} catch {
+			// ignore
+		}
+	}
+
+	return null;
+}
+
+describe("mcp server (unit)", () => {
+	test("responds to tools/list and analyzeTransaction", async () => {
+		const proc = Bun.spawn(["bun", "run", "src/cli/index.ts", "mcp"], {
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+			env: {
+				...process.env,
+				RUGSCAN_MCP_STUB_DEPS: "1",
+				RUGSCAN_CONFIG: "test/fixtures/empty-config.json",
+			},
+		});
+
+		const reader = proc.stdout.getReader();
+		const stdin = proc.stdin;
+		if (!stdin) {
+			proc.kill();
+			throw new Error("Failed to open stdin pipe");
+		}
+
+		type NodeLikeStdin = {
+			write: (chunk: Uint8Array) => unknown;
+			end?: () => unknown;
+		};
+
+		type WebLikeStdin = {
+			getWriter: () => WritableStreamDefaultWriter<Uint8Array>;
+		};
+
+		const hasWrite = (value: unknown): value is NodeLikeStdin => {
+			return isRecord(value) && typeof value.write === "function";
+		};
+
+		const hasGetWriter = (value: unknown): value is WebLikeStdin => {
+			return isRecord(value) && typeof value.getWriter === "function";
+		};
+
+		const writeStdin = async (data: Uint8Array) => {
+			if (hasWrite(stdin)) {
+				stdin.write(data);
+				await Bun.sleep(0);
+				return;
+			}
+
+			if (hasGetWriter(stdin)) {
+				const writer = stdin.getWriter();
+				await writer.write(data);
+				return;
+			}
+
+			throw new Error("Unsupported stdin pipe type");
+		};
+
+		await writeStdin(
+			encodeMessage({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {
+					protocolVersion: "2024-11-05",
+					clientInfo: { name: "rugscan-test", version: "0" },
+					capabilities: {},
+				},
+			}),
+		);
+		const init = await readMessage(reader);
+		expect(init).toHaveProperty("result");
+
+		await writeStdin(
+			encodeMessage({
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/list",
+				params: {},
+			}),
+		);
+		const list = await readMessage(reader);
+		expect(JSON.stringify(list)).toContain("rugscan.analyzeTransaction");
+
+		await writeStdin(
+			encodeMessage({
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: {
+					name: "rugscan.analyzeTransaction",
+					arguments: {
+						chain: "ethereum",
+						to: "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
+						from: "0x24274566a1ad6a9b056e8e2618549ebd2f5141a7",
+						data: "0x",
+						value: "0",
+						noSim: true,
+						walletMode: true,
+					},
+				},
+			}),
+		);
+		const call = await readMessage(reader);
+
+		const result = isRecord(call) ? call.result : undefined;
+		const found = findAnalyzeResponseInToolResult(result);
+		expect(found?.schemaVersion).toBe(1);
+
+		proc.kill();
+		await proc.exited;
+	}, 30_000);
+});


### PR DESCRIPTION
Adds a minimal MCP (Model Context Protocol) server over stdio via `rugscan mcp`.

Tools:
- `rugscan.analyzeTransaction`
- `rugscan.analyzeAddress`

Includes a deterministic unit test exercising `tools/list` and `tools/call` for analyzeTransaction.
