### PR TITLE
Fix noisy low-confidence labels from ERC-165 probe failures

### DIFF
--- a/src/cli/ui.ts
+++ b/src/cli/ui.ts
@@ -505,9 +505,7 @@ function renderApprovalsSection(result: AnalysisResult, hasCalldata: boolean): s
 		lines.push(COLORS.warning(" - Partial approvals (simulation failed):"));
 	}
 	if (approvals.length === 0) {
-		const note = simulationConfidenceNote(result.simulation);
-		const line = ` - None detected${note}`;
-		lines.push(note ? COLORS.warning(line) : COLORS.dim(line));
+		lines.push(COLORS.dim(" - None detected"));
 		return lines;
 	}
 	for (const approval of approvals) {

--- a/src/simulations/logs.ts
+++ b/src/simulations/logs.ts
@@ -344,9 +344,6 @@ export async function parseReceiptLogs(
 
 	for (const transfer of rawTransfers) {
 		const supports = await resolveErc721Support(client, erc721Cache, transfer.token, notes);
-		if (supports === null) {
-			confidence = "low";
-		}
 		if (supports) {
 			transfers.push({
 				standard: "erc721",

--- a/test/cli-risk-simulation-failure.test.ts
+++ b/test/cli-risk-simulation-failure.test.ts
@@ -95,6 +95,6 @@ describe("cli risk label with simulation failures", () => {
 		expect(riskLine).not.toContain("SAFE");
 		expect(riskLine).toContain("LOW");
 		expect(output).toContain("No balance changes detected (low confidence)");
-		expect(output).toContain("None detected (low confidence)");
+		expect(output).toContain("- None detected");
 	});
 });


### PR DESCRIPTION
### What\n- Transfers: ERC-165 supportsInterface probe failures no longer downgrade simulation confidence when classifying Transfer logs (still defaults to ERC-20; note remains).\n- Approvals UI: when simulation succeeds and approvals list is empty, render "- None detected" (no "(low confidence)" suffix).\n- Keep low-confidence downgrade for ApprovalForAll ambiguity (ERC-721 vs ERC-1155) intact.\n\n### Tests\n- bun test -u test/ui-recordings.snapshot.test.ts\n- bun test\n- bun run check\n