### PR TITLE
feat: balance delta engine (wallet-fast) — Issue #40

### DIFF
--- a/src/scan.ts
+++ b/src/scan.ts
@@ -112,7 +112,7 @@ export async function scanWithAnalysis(
 		options?.config,
 		options?.progress,
 		options?.timings,
-		{ offline: options?.offline },
+		{ offline: options?.offline, mode: analyzeOptions?.mode },
 	);
 	const withSimulation = simulation ? { ...mergedAnalysis, simulation } : mergedAnalysis;
 	const finalAnalysis = applySimulationVerdict(normalizedInput, withSimulation);
@@ -236,7 +236,7 @@ async function runBalanceSimulation(
 	config: Config | undefined,
 	progress: ScanProgress | undefined,
 	timings: TimingStore | undefined,
-	options?: { offline?: boolean },
+	options?: { offline?: boolean; mode?: "default" | "wallet" },
 ): Promise<BalanceSimulationResult | undefined> {
 	if (!input.calldata) return undefined;
 
@@ -249,6 +249,7 @@ async function runBalanceSimulation(
 
 	const result = await simulateBalance(input.calldata, chain, config, timings, {
 		offline: options?.offline,
+		mode: options?.mode,
 	});
 	progress?.({
 		provider: "Simulation",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -28,7 +28,7 @@ export interface AssetChange {
 }
 
 export interface ApprovalChange {
-	standard: "erc20" | "erc721" | "erc1155";
+	standard: "erc20" | "erc721" | "erc1155" | "permit2";
 	token: string;
 	owner: string;
 	spender: string;
@@ -36,6 +36,8 @@ export interface ApprovalChange {
 	tokenId?: string;
 	scope?: "token" | "all";
 	approved?: boolean;
+	symbol?: string;
+	decimals?: number;
 }
 
 export interface BalanceSimulationResult {

--- a/src/simulations/delta-engine.ts
+++ b/src/simulations/delta-engine.ts
@@ -1,0 +1,122 @@
+import type { Address } from "viem";
+import type { AssetChange } from "../types";
+import type { ParsedTransfer } from "./logs";
+
+export interface WalletFastDeltaEngineResult {
+	tokens: Address[];
+	assetChanges: AssetChange[];
+	notes: string[];
+	confidence: "high" | "medium" | "low";
+}
+
+export function selectWalletFastErc20Tokens(options: {
+	actor: Address;
+	transfers: ParsedTransfer[];
+	maxTokens?: number;
+}): { tokens: Address[]; truncated: boolean } {
+	const actor = options.actor.toLowerCase();
+	const sorted = [...options.transfers].sort((a, b) => a.logIndex - b.logIndex);
+	const seen = new Set<string>();
+	const out: Address[] = [];
+	for (const transfer of sorted) {
+		if (transfer.standard !== "erc20") continue;
+		if (transfer.from.toLowerCase() !== actor && transfer.to.toLowerCase() !== actor) continue;
+		const key = transfer.token.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(transfer.token);
+		if (options.maxTokens !== undefined && out.length >= options.maxTokens) {
+			break;
+		}
+	}
+
+	const truncated =
+		options.maxTokens !== undefined &&
+		out.length >= options.maxTokens &&
+		sorted.some((transfer) => {
+			if (transfer.standard !== "erc20") return false;
+			if (transfer.from.toLowerCase() !== actor && transfer.to.toLowerCase() !== actor)
+				return false;
+			return !seen.has(transfer.token.toLowerCase());
+		});
+
+	return { tokens: out, truncated };
+}
+
+export function buildWalletFastErc20Changes(options: {
+	actor: Address;
+	transfers: ParsedTransfer[];
+	tokens: Address[];
+	before: Map<Address, bigint>;
+	after: Map<Address, bigint>;
+}): AssetChange[] {
+	const actor = options.actor.toLowerCase();
+	const transfers = [...options.transfers].sort((a, b) => a.logIndex - b.logIndex);
+
+	const changes: AssetChange[] = [];
+	for (const token of options.tokens) {
+		const before = options.before.get(token) ?? null;
+		const after = options.after.get(token) ?? null;
+		if (before === null || after === null) continue;
+		const diff = after - before;
+		if (diff === 0n) continue;
+
+		const counterparty = uniqueCounterparty({ transfers, actor, token });
+		changes.push({
+			assetType: "erc20",
+			address: token,
+			amount: diff < 0n ? -diff : diff,
+			direction: diff < 0n ? "out" : "in",
+			counterparty: counterparty ?? undefined,
+		});
+	}
+
+	changes.sort((a, b) => {
+		const aAddr = (a.address ?? "").toLowerCase();
+		const bAddr = (b.address ?? "").toLowerCase();
+		if (aAddr < bAddr) return -1;
+		if (aAddr > bAddr) return 1;
+		if (a.direction === b.direction) return 0;
+		return a.direction === "out" ? -1 : 1;
+	});
+
+	return changes;
+}
+
+function uniqueCounterparty(options: {
+	transfers: ParsedTransfer[];
+	actor: string;
+	token: Address;
+}): Address | null {
+	const token = options.token.toLowerCase();
+	let counterparty: Address | null = null;
+	let counterpartyKey: string | null = null;
+
+	for (const transfer of options.transfers) {
+		if (transfer.standard !== "erc20") continue;
+		if (transfer.token.toLowerCase() !== token) continue;
+
+		if (transfer.from.toLowerCase() === options.actor) {
+			const other = transfer.to;
+			const otherKey = other.toLowerCase();
+			if (counterpartyKey && counterpartyKey !== otherKey) {
+				return null;
+			}
+			counterparty = other;
+			counterpartyKey = otherKey;
+			continue;
+		}
+
+		if (transfer.to.toLowerCase() === options.actor) {
+			const other = transfer.from;
+			const otherKey = other.toLowerCase();
+			if (counterpartyKey && counterpartyKey !== otherKey) {
+				return null;
+			}
+			counterparty = other;
+			counterpartyKey = otherKey;
+		}
+	}
+
+	return counterparty;
+}

--- a/test/wallet-fast-delta-engine.fixture.test.ts
+++ b/test/wallet-fast-delta-engine.fixture.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { type Address, isAddress } from "viem";
+import {
+	buildWalletFastErc20Changes,
+	selectWalletFastErc20Tokens,
+} from "../src/simulations/delta-engine";
+import type { ParsedTransfer } from "../src/simulations/logs";
+
+const recordingsDir = path.join(import.meta.dir, "fixtures", "recordings");
+
+type ExpectedDelta = {
+	address: Address;
+	amount: bigint;
+	direction: "in" | "out";
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseFixtureAddress(value: unknown, label: string): Address {
+	if (typeof value !== "string" || !isAddress(value)) {
+		throw new Error(`Invalid ${label} address in fixture`);
+	}
+	return value;
+}
+
+function parseExpectedDeltas(value: unknown): ExpectedDelta[] {
+	if (!Array.isArray(value)) {
+		throw new Error("Fixture simulation.assetChanges must be an array");
+	}
+	const out: ExpectedDelta[] = [];
+	for (const entry of value) {
+		if (!isRecord(entry)) {
+			throw new Error("Fixture asset change must be an object");
+		}
+		if (entry.assetType !== "erc20") continue;
+		const address = parseFixtureAddress(entry.address, "assetChanges.address");
+		if (entry.direction !== "in" && entry.direction !== "out") {
+			throw new Error("Fixture assetChanges.direction must be in/out");
+		}
+		if (typeof entry.amount !== "string") {
+			throw new Error("Fixture assetChanges.amount must be a string");
+		}
+		out.push({
+			address,
+			amount: BigInt(entry.amount),
+			direction: entry.direction,
+		});
+	}
+	return out;
+}
+
+async function loadRecording(name: string): Promise<{ actor: Address; expected: ExpectedDelta[] }> {
+	const calldataPath = path.join(recordingsDir, name, "calldata.json");
+	const responsePath = path.join(recordingsDir, name, "analyzeResponse.json");
+
+	const calldataRaw: unknown = JSON.parse(await readFile(calldataPath, "utf-8"));
+	const responseRaw: unknown = JSON.parse(await readFile(responsePath, "utf-8"));
+
+	if (!isRecord(calldataRaw)) {
+		throw new Error(`Invalid calldata fixture: ${name}`);
+	}
+	const actor = parseFixtureAddress(calldataRaw.from, "calldata.from");
+
+	if (!isRecord(responseRaw) || !isRecord(responseRaw.scan)) {
+		throw new Error(`Invalid analyzeResponse fixture: ${name}`);
+	}
+	const simulation = responseRaw.scan.simulation;
+	if (!isRecord(simulation)) {
+		throw new Error(`Missing simulation fixture: ${name}`);
+	}
+
+	return {
+		actor,
+		expected: parseExpectedDeltas(simulation.assetChanges),
+	};
+}
+
+function buildSyntheticTransfers(
+	actor: Address,
+	expected: ExpectedDelta[],
+	fallbackCounterparty: Address,
+): ParsedTransfer[] {
+	const transfers: ParsedTransfer[] = [];
+	for (const [index, delta] of expected.entries()) {
+		transfers.push({
+			standard: "erc20",
+			token: delta.address,
+			from: delta.direction === "out" ? actor : fallbackCounterparty,
+			to: delta.direction === "out" ? fallbackCounterparty : actor,
+			amount: delta.amount,
+			logIndex: index,
+		});
+	}
+	return transfers;
+}
+
+let originalFetch: typeof globalThis.fetch;
+let networkCallCount = 0;
+
+beforeEach(() => {
+	networkCallCount = 0;
+	originalFetch = globalThis.fetch;
+	globalThis.fetch = async () => {
+		networkCallCount += 1;
+		throw new Error("Network calls are disabled in wallet-fast delta fixtures");
+	};
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	expect(networkCallCount).toBe(0);
+});
+
+describe("wallet-fast delta engine (fixture-backed)", () => {
+	test("wallet-approve-usdc-unlimited-f7bf0220 preserves zero ERC-20 balance delta", async () => {
+		const fixture = await loadRecording("wallet-approve-usdc-unlimited-f7bf0220");
+		const actor = fixture.actor;
+		const fallbackCounterparty = parseFixtureAddress(
+			"0x0000000000000000000000000000000000000001",
+			"fallbackCounterparty",
+		);
+		const transfers = buildSyntheticTransfers(actor, fixture.expected, fallbackCounterparty);
+
+		const selected = selectWalletFastErc20Tokens({
+			actor,
+			transfers,
+			maxTokens: 12,
+		});
+
+		const before = new Map<Address, bigint>();
+		const after = new Map<Address, bigint>();
+		for (const delta of fixture.expected) {
+			if (delta.direction === "out") {
+				before.set(delta.address, delta.amount);
+				after.set(delta.address, 0n);
+				continue;
+			}
+			before.set(delta.address, 0n);
+			after.set(delta.address, delta.amount);
+		}
+
+		const computed = buildWalletFastErc20Changes({
+			actor,
+			transfers,
+			tokens: selected.tokens,
+			before,
+			after,
+		});
+
+		const normalized = computed.map((change) => ({
+			address: change.address,
+			amount: change.amount,
+			direction: change.direction,
+		}));
+
+		expect(normalized).toEqual(fixture.expected);
+	});
+
+	test("wallet-uniswap-swap-rlp-to-eth-fb2584e4 preserves ERC-20 outflow delta", async () => {
+		const fixture = await loadRecording("wallet-uniswap-swap-rlp-to-eth-fb2584e4");
+		const actor = fixture.actor;
+		const fallbackCounterparty = parseFixtureAddress(
+			"0x0000000000000000000000000000000000000001",
+			"fallbackCounterparty",
+		);
+		const transfers = buildSyntheticTransfers(actor, fixture.expected, fallbackCounterparty);
+
+		const selected = selectWalletFastErc20Tokens({
+			actor,
+			transfers,
+			maxTokens: 12,
+		});
+
+		const before = new Map<Address, bigint>();
+		const after = new Map<Address, bigint>();
+		for (const delta of fixture.expected) {
+			if (delta.direction === "out") {
+				before.set(delta.address, delta.amount);
+				after.set(delta.address, 0n);
+				continue;
+			}
+			before.set(delta.address, 0n);
+			after.set(delta.address, delta.amount);
+		}
+
+		const computed = buildWalletFastErc20Changes({
+			actor,
+			transfers,
+			tokens: selected.tokens,
+			before,
+			after,
+		});
+
+		const normalized = computed.map((change) => ({
+			address: change.address,
+			amount: change.amount,
+			direction: change.direction,
+		}));
+
+		expect(normalized).toEqual(fixture.expected);
+	});
+});


### PR DESCRIPTION
## Summary
- add a wallet-fast ERC-20 delta engine (`selectWalletFastErc20Tokens` + `buildWalletFastErc20Changes`)
- wire wallet-mode simulation through `scan -> simulateBalance` so wallet scans use the fast delta path
- switch sender contract detection to run on the active fork client (removes an extra RPC hop)
- add fixture-backed wallet-fast delta tests for recorded wallet transactions with network disabled

## Validation
- `bun run check`
- `bun test`

Closes #40
