### PR TITLE
docs: rename Rugscan to Assay in narrative docs (no CLI/API changes)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,8 +1,8 @@
-# Agent integrations (rugscan)
+# Agent integrations (Assay)
 
-This doc describes **supported integration modes** for using rugscan as a preflight security gate before submitting EVM transactions.
+This doc describes **supported integration modes** for using Assay (formerly Rugscan) as a preflight security gate before submitting EVM transactions.
 
-> Scope note: rugscan is **EVM / Ethereum JSON-RPC only** right now.
+> Scope note: Assay is **EVM / Ethereum JSON-RPC only** right now.
 > The integration points below specifically target `eth_sendTransaction` and `eth_sendRawTransaction`.
 
 ## Mode 1 (preferred): In-process wrapper (agent-native)
@@ -14,7 +14,7 @@ Wrap your existing `viem` transport and block risky transactions *before* they h
 - Intercepts:
   - `eth_sendTransaction`
   - `eth_sendRawTransaction`
-- Runs the full rugscan pipeline in-process (`scanWithAnalysis`).
+- Runs the full Assay pipeline in-process (`scanWithAnalysis`).
 - If risky/unknown, throws `RugscanTransportError` containing:
   - `analyzeResponse` (structured)
   - `renderedSummary` (human-readable string)
@@ -74,7 +74,7 @@ This repo currently ships the viem wrapper as the “serious” integration path
 
 ## Mode 2: CLI preflight gate
 
-Run rugscan as a **preflight check** in an agent/tool workflow before signing/sending.
+Run Assay as a **preflight check** in an agent/tool workflow before signing/sending.
 
 - `rugscan scan ... --fail-on <threshold>` exits non-zero when recommendation >= threshold.
 - Useful when you can’t easily wrap a provider, or you want a one-shot shell step.
@@ -102,7 +102,7 @@ rugscan exec -- <command>
 
 Behavior:
 
-1. Start a local rugscan proxy bound to `127.0.0.1:<port>`.
+1. Start a local Assay proxy bound to `127.0.0.1:<port>`.
 2. Run `<command>` with `RPC_URL` (and/or common aliases like `ETH_RPC_URL`) set to the proxy URL.
 3. Proxy intercepts `eth_sendTransaction` / `eth_sendRawTransaction` and blocks risky/unknown.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Rugscan Target Architecture
+# Assay (formerly Rugscan) Target Architecture
 
 This is the desired architecture for the simplified, local-first CLI.
 

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,4 +1,4 @@
-# Rugscan Security Audit (current codebase)
+# Assay (formerly Rugscan) Security Audit (current codebase)
 
 Scope reviewed:
 - Core analysis flow: `src/analyzer.ts`, `src/approval.ts`, `src/scan.ts`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# Rugscan Roadmap ("Blowfish, but open source and local")
+# Assay (formerly Rugscan) Roadmap ("Blowfish, but open source and local")
 
 Effort scale:
 - S: 0.5-1 day

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -3,4 +3,4 @@
 This document is superseded by:
 - `docs/ARCHITECTURE.md`
 
-As of v1, rugscan analysis is deterministic-only (no cloud model analysis). Any prior design notes about model-based analysis have been removed.
+As of v1, Assay (formerly Rugscan) analysis is deterministic-only (no cloud model analysis). Any prior design notes about model-based analysis have been removed.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,4 +1,4 @@
-# rugscan Code Review
+# Assay (formerly Rugscan) Code Review
 
 Scope: `src/types.ts`, `src/chains.ts`, `src/analyzer.ts`, `src/providers/*.ts`, `src/cli/index.ts`
 

--- a/docs/research/multi-interface-design.md
+++ b/docs/research/multi-interface-design.md
@@ -1,8 +1,8 @@
-# Multi-Interface Design Research for rugscan
+# Multi-Interface Design Research for Assay (formerly Rugscan)
 Date: 2026-02-02
 
 ## Summary
-rugscan should expose one core analysis engine with four adapters: CLI, REST API, SDK, and MCP. Existing security tools are CLI-first with rich structured outputs (JSON/SARIF) and config files. Wallet-facing security engines emphasize fast pre-sign simulation, balance-change previews, and clear risk signals. Agent-friendly CLIs prioritize machine-readable output, deterministic exit codes, and stdin/stdout workflows.
+Assay should expose one core analysis engine with four adapters: CLI, REST API, SDK, and MCP. Existing security tools are CLI-first with rich structured outputs (JSON/SARIF) and config files. Wallet-facing security engines emphasize fast pre-sign simulation, balance-change previews, and clear risk signals. Agent-friendly CLIs prioritize machine-readable output, deterministic exit codes, and stdin/stdout workflows.
 
 ## Research Findings
 
@@ -82,9 +82,9 @@ Common inputs in this space include:
 - MCP is an open protocol that lets AI apps connect to tools/resources and discover them at runtime. (Source: MCP Introduction)
 - MCP defines a tool discovery and invocation flow (`tools/list`, `tools/call`) via JSON-RPC, and it expects the client to control human-in-the-loop approval. (Source: MCP Tools spec)
 
-**Pattern to carry forward:** provide a rugscan MCP server that exposes primitive scan tools and returns rich structured output; keep workflow logic in the agent, not the tool.
+**Pattern to carry forward:** provide an Assay MCP server that exposes primitive scan tools and returns rich structured output; keep workflow logic in the agent, not the tool.
 
-## Recommendations for rugscan
+## Recommendations for Assay
 
 ### A) One core analysis engine + four adapters
 - **Core engine**: pure analysis that returns a stable `ScanResult` schema.

--- a/docs/research/post-scam-hooks.md
+++ b/docs/research/post-scam-hooks.md
@@ -1,9 +1,9 @@
 # Post-Scam Hooks & Agent Integration (Exploratory)
 
-Goal: define a post-scam hook system for Rugscan that triggers when a scam/rug is detected, routes signals to humans/agents, and feeds collective intelligence without leaking sensitive user data.
+Goal: define a post-scam hook system for Assay (formerly Rugscan) that triggers when a scam/rug is detected, routes signals to humans/agents, and feeds collective intelligence without leaking sensitive user data.
 
 ## Assumptions
-- Rugscan already produces pre-trade warnings and can classify post-trade outcomes.
+- Assay already produces pre-trade warnings and can classify post-trade outcomes.
 - "Post-scam" events should be evidence-backed and versioned to prevent noisy alerts.
 - Some integrations may require manual review or rate limits in early milestones.
 

--- a/docs/research/presign-ux-patterns.md
+++ b/docs/research/presign-ux-patterns.md
@@ -1,7 +1,7 @@
 # Pre-sign transaction security scanner UX patterns
 
 Research date: 2026-02-02
-Scope: wallet pre-sign UX, security tools, CLI input patterns, and integration models
+Scope: wallet pre-sign UX, security tools, CLI input patterns, and integration models for Assay (formerly Rugscan).
 
 ## Executive takeaways
 - Wallets rarely expose a full JSON export of unsigned transactions; the most common advanced view is raw hex (often hidden behind an advanced toggle). Copy/export is usually manual select/copy, not a dedicated button.
@@ -24,9 +24,9 @@ Notes:
 | Rainbow | Review screens focus on human-readable swap/bridge details (network, min received, fees, slippage, gas) with editable gas. | No raw data export mentioned in support docs. | Human-readable summary fields. | Rainbow support docs for swap/bridge review screens. |
 | Coinbase Wallet / Base app | Official docs emphasize network fee customization (max fee, priority fee, gas limit). | No raw data export mentioned in official docs. | Human-readable summary + gas fee customization. | Coinbase Help docs for adjusting network fees. |
 
-Implications for Rugscan:
+Implications for Assay:
 - Do not rely on wallets to give you a ready JSON export. Offer multiple input paths: raw hex, calldata + to/value, or JSON-RPC payload.
-- Provide a one-click "copy for Rugscan" in your own UI if you build a wallet plugin/extension.
+- Provide a one-click "copy for Assay" in your own UI if you build a wallet plugin/extension.
 
 ## 2) Existing pre-sign security tools
 
@@ -47,7 +47,7 @@ Notes:
 - `cast send` (Foundry) accepts raw hex data via `--data`, or ABI signature + args, with flags for `--rpc-url`, `--chain`, `--value`, gas options, etc. This is a clear multi-input model that favors flags and optional raw hex overrides.
 - `slither` is path-based (analyze a project or file) rather than transaction-input driven. Its CLI shows a "single command with options" pattern for security tooling, not JSON payloads.
 
-### Recommended CLI inputs for Rugscan
+### Recommended CLI inputs for Assay
 Support multiple formats and normalize internally to a single canonical schema:
 
 1) JSON (stdin or file)

--- a/docs/simplification-plan.md
+++ b/docs/simplification-plan.md
@@ -1,4 +1,4 @@
-# Rugscan Simplification Plan
+# Assay (formerly Rugscan) Simplification Plan
 
 ## Assumptions
 - Primary product is a local CLI for quick contract checks.


### PR DESCRIPTION
## Summary
- docs-only branding pass across selected narrative docs
- updated first mentions to use **Assay (formerly Rugscan)**
- replaced narrative Rugscan/rugscan references with Assay/assay where appropriate

## Compatibility notes
- No runtime or API behavior changes
- CLI/API compatibility literals were intentionally preserved (e.g. `rugscan` command examples, package/class identifiers like `RugscanTransportError`, and compatibility literals such as `RUGSCAN_*`)

## Scope
Only these files were edited:
- docs/AGENTS.md
- docs/AUDIT.md
- docs/ARCHITECTURE.md
- docs/ROADMAP.md
- docs/architecture-review.md
- docs/code-review.md
- docs/simplification-plan.md
- docs/research/multi-interface-design.md
- docs/research/presign-ux-patterns.md
- docs/research/post-scam-hooks.md
