### PR TITLE
refactor!: full rename to Assay (breaking, no compat aliases)

### DIFF
--- a/.github/workflows/ci-comprehensive.yml
+++ b/.github/workflows/ci-comprehensive.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
 
     env:
-      RUGSCAN_LIVE_TESTS: "1"
-      RUGSCAN_FORK_E2E: "1"
+      ASSAY_LIVE_TESTS: "1"
+      ASSAY_FORK_E2E: "1"
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rugscan
+# assay
 
 Pre-transaction security analysis for EVM contracts. Know what you're signing before you sign it.
 
@@ -14,16 +14,16 @@ Pre-transaction security analysis for EVM contracts. Know what you're signing be
 
 ## Install
 
-> Note: rugscan is not published to npm yet.
+> Note: assay is not published to npm yet.
 
 For now, run from source:
 
 ```bash
-git clone https://github.com/marcomariscal/rugscan
-cd rugscan
+git clone <REPO_URL>
+cd <REPO_DIR>
 bun install
 
-# examples below use `rugscan ...`; when running from source, replace with:
+# examples below use `assay ...`; when running from source, replace with:
 # bun run src/cli/index.ts ...
 ```
 
@@ -31,34 +31,34 @@ bun install
 
 ```bash
 # Basic analysis
-rugscan analyze 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+assay analyze 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
 
 # Approval analysis
-rugscan approval --token 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
+assay approval --token 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 \
   --spender 0xE592427A0AEce92De3Edee1F18E0157C05861564 \
   --amount max \
   --expected 0xE592427A0AEce92De3Edee1F18E0157C05861564
 
 # Different chain
-rugscan analyze 0x1234... --chain base
+assay analyze 0x1234... --chain base
 ```
 
 ## CLI Usage
 
-Run `rugscan --help` for the full CLI reference.
+Run `assay --help` for the full CLI reference.
 
 ```bash
-rugscan analyze <address> [options]
-rugscan scan [address] [options]
-rugscan safe <chain> <safeTxHash> [--safe-tx-json <path>] [--offline]
-rugscan approval --token <address> --spender <address> --amount <value> [--expected <address>] [--chain <chain>]
-rugscan proxy [options]
-rugscan mcp
+assay analyze <address> [options]
+assay scan [address] [options]
+assay safe <chain> <safeTxHash> [--safe-tx-json <path>] [--offline]
+assay approval --token <address> --spender <address> --amount <value> [--expected <address>] [--chain <chain>]
+assay proxy [options]
+assay mcp
 ```
 
-### `rugscan scan`
+### `assay scan`
 
-`rugscan scan` analyzes either a contract address or an unsigned transaction (calldata) before signing.
+`assay scan` analyzes either a contract address or an unsigned transaction (calldata) before signing.
 
 Flags:
 - `--format text|json|sarif` (default: `text`)
@@ -70,7 +70,7 @@ Flags:
   - `-` to read from stdin
 - `--to/--from/--value` — when `--calldata` is raw hex (or when providing tx fields directly)
 - `--no-sim` — disable Anvil simulation
-  - By default, rugscan will try to run an **Anvil fork simulation** for transaction inputs. Simulation success + decoded intent is the primary signal when available.
+  - By default, assay will try to run an **Anvil fork simulation** for transaction inputs. Simulation success + decoded intent is the primary signal when available.
 - `--fail-on <caution|warning|danger>` — set exit threshold (default: `warning`)
 - `--output <path|->` (default: `-`)
 - `--quiet` — suppress progress/logging
@@ -78,22 +78,22 @@ Flags:
 Examples:
 
 ```bash
-rugscan scan 0x1234...
-rugscan scan --calldata @tx.json --format json
-cat tx.json | rugscan scan --calldata - --format sarif
+assay scan 0x1234...
+assay scan --calldata @tx.json --format json
+cat tx.json | assay scan --calldata - --format sarif
 
 # MetaMask "Hex Data" (raw calldata)
-rugscan scan --calldata 0x... --to 0x... --from 0x... --value 0 --format json
+assay scan --calldata 0x... --to 0x... --from 0x... --value 0 --format json
 ```
 
-### `rugscan proxy`
+### `assay proxy`
 
-`rugscan proxy` runs a local JSON-RPC proxy for wallets. It intercepts send-transaction calls, runs `rugscan scan`, and blocks or prompts based on risk.
+`assay proxy` runs a local JSON-RPC proxy for wallets. It intercepts send-transaction calls, runs `assay scan`, and blocks or prompts based on risk.
 
 ```bash
-rugscan proxy --upstream https://... --chain ethereum
-rugscan proxy --wallet
-rugscan proxy --record-dir ./rugscan-recordings
+assay proxy --upstream https://... --chain ethereum
+assay proxy --wallet
+assay proxy --record-dir ./assay-recordings
 ```
 
 Notes:
@@ -115,12 +115,12 @@ Notes:
 Run an MCP server over stdio:
 
 ```bash
-rugscan mcp
+assay mcp
 ```
 
 Tools exposed:
-- `rugscan.analyzeTransaction`
-- `rugscan.analyzeAddress`
+- `assay.analyzeTransaction`
+- `assay.analyzeAddress`
 
 ## Output
 
@@ -144,11 +144,11 @@ Tools exposed:
 ```
 
 **Exit codes (not a guarantee):**
-- `rugscan analyze` / `rugscan approval`:
+- `assay analyze` / `assay approval`:
   - `0` — OK per configured checks (no findings at/above the built-in thresholds)
   - `1` — CAUTION/WARNING
   - `2` — DANGER
-- `rugscan scan`:
+- `assay scan`:
   - `0` — recommendation is below `--fail-on`
   - `2` — recommendation is >= `--fail-on` (default: `warning`)
   - `1` — invalid flags or runtime error
@@ -169,7 +169,7 @@ Without keys, analysis uses Sourcify only.
 
 ### Config File (alternative to env vars)
 
-Create `./rugscan.config.json` or `~/.config/rugscan/config.json`:
+Create `./assay.config.json` or `~/.config/assay/config.json`:
 
 ```json
 {
@@ -183,11 +183,11 @@ Create `./rugscan.config.json` or `~/.config/rugscan/config.json`:
 }
 ```
 
-Override location with `RUGSCAN_CONFIG=/path/to/config.json`.
+Override location with `ASSAY_CONFIG=/path/to/config.json`.
 
 ### Proxy Allowlist (v1)
 
-When running `rugscan proxy`, you can optionally enforce a local allowlist so transactions are blocked unless they only touch trusted endpoints.
+When running `assay proxy`, you can optionally enforce a local allowlist so transactions are blocked unless they only touch trusted endpoints.
 
 Config:
 
@@ -210,7 +210,7 @@ Notes:
 ## Library Usage
 
 ```typescript
-import { analyze, analyzeApproval } from "rugscan";
+import { analyze, analyzeApproval } from "assay";
 
 const result = await analyze("0x1234...", "ethereum", {
   etherscanKeys: {
@@ -287,7 +287,7 @@ console.log(approvalResult.spenderAnalysis); // AnalysisResult
 
 GitHub Actions runs two tiers of CI:
 - **Tier 1 (PR gating)**: `.github/workflows/ci.yml` runs default `bun test` (skips live-network + fork/anvil e2e suites)
-- **Tier 2 (comprehensive)**: `.github/workflows/ci-comprehensive.yml` runs nightly + manual (`workflow_dispatch`) with `RUGSCAN_LIVE_TESTS=1` and `RUGSCAN_FORK_E2E=1`
+- **Tier 2 (comprehensive)**: `.github/workflows/ci-comprehensive.yml` runs nightly + manual (`workflow_dispatch`) with `ASSAY_LIVE_TESTS=1` and `ASSAY_FORK_E2E=1`
 
 ```bash
 # Install deps
@@ -297,13 +297,13 @@ bun install
 bun test
 
 # Tier 2 (optional): run tests that hit live provider APIs (Sourcify/GoPlus/DeFiLlama/etc)
-RUGSCAN_LIVE_TESTS=1 bun test
+ASSAY_LIVE_TESTS=1 bun test
 
 # Tier 2 (optional): run fork/anvil e2e suites (requires Foundry's `anvil`)
-RUGSCAN_FORK_E2E=1 bun test
+ASSAY_FORK_E2E=1 bun test
 
 # Run everything
-RUGSCAN_LIVE_TESTS=1 RUGSCAN_FORK_E2E=1 bun test
+ASSAY_LIVE_TESTS=1 ASSAY_FORK_E2E=1 bun test
 
 # Build
 bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "rugscan",
+      "name": "assay",
       "dependencies": {
         "picocolors": "^1.1.1",
         "viem": "^2.45.1",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Rugscan Target Architecture
+# Assay Target Architecture
 
 This is the desired architecture for the simplified, local-first CLI.
 
@@ -39,7 +39,7 @@ This is the desired architecture for the simplified, local-first CLI.
                  | - exit code           |
                  +-----------------------+
 
-## Data flow for `rugscan check <address>`
+## Data flow for `assay check <address>`
 
 1) CLI parses address + chain; config is loaded from env/file.
 2) Orchestrator normalizes address and starts provider calls in parallel:

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -1,4 +1,4 @@
-# Rugscan Security Audit (current codebase)
+# Assay Security Audit (current codebase)
 
 Scope reviewed:
 - Core analysis flow: `src/analyzer.ts`, `src/approval.ts`, `src/scan.ts`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,4 +1,4 @@
-# Rugscan Roadmap ("Blowfish, but open source and local")
+# Assay Roadmap ("Blowfish, but open source and local")
 
 Effort scale:
 - S: 0.5-1 day
@@ -9,7 +9,7 @@ Effort scale:
 The phases below reflect the simplification plan and a staged path to 99% and 99.9% coverage.
 
 ## Phase 1: Core simplification (minimal local CLI)
-Goal: ship a fast, local `rugscan check` and `rugscan approval` with high-signal findings only.
+Goal: ship a fast, local `assay check` and `assay approval` with high-signal findings only.
 
 Tasks (Phase 1)
 1) Collapse CLI to `check` + `approval` only, remove `scan` and `analyze`
@@ -41,7 +41,7 @@ Tasks (Phase 1)
    - Effort: S
 
 Phase 1 success criteria
-- `rugscan check 0x...` completes in seconds and prints 1-3 findings
+- `assay check 0x...` completes in seconds and prints 1-3 findings
 - No AI, server, or simulation dependencies
 - Exit codes reflect severity (0 ok, 1 risky, 2 danger)
 - No external writes, no background services

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -3,4 +3,4 @@
 This document is superseded by:
 - `docs/ARCHITECTURE.md`
 
-As of v1, rugscan analysis is deterministic-only (no cloud model analysis). Any prior design notes about model-based analysis have been removed.
+As of v1, assay analysis is deterministic-only (no cloud model analysis). Any prior design notes about model-based analysis have been removed.

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,4 +1,4 @@
-# rugscan Code Review
+# assay Code Review
 
 Scope: `src/types.ts`, `src/chains.ts`, `src/analyzer.ts`, `src/providers/*.ts`, `src/cli/index.ts`
 

--- a/docs/decisions/cli-input-scope.md
+++ b/docs/decisions/cli-input-scope.md
@@ -22,10 +22,10 @@ Status: proposed
 Support exactly two input shapes:
 
 1) Address scan (existing usage)
-- `rugscan scan <address> [--chain <chain>]`
+- `assay scan <address> [--chain <chain>]`
 
 2) Calldata scan (canonical JSON)
-- `rugscan scan --calldata <json|@file|-> [--chain <chain>]`
+- `assay scan --calldata <json|@file|-> [--chain <chain>]`
 
 Calldata JSON schema (canonical):
 ```json

--- a/docs/plans/assay-full-rename.md
+++ b/docs/plans/assay-full-rename.md
@@ -1,0 +1,42 @@
+# Assay full rename execution plan
+
+Date: 2026-02-09
+Branch: `chore/assay-branding-full-rename`
+
+## Goal
+Perform a full product rename to **Assay** across code, CLI/API surfaces, config/env names, docs, tests, fixtures, and scripts with no backward-compat aliases unless build/runtime requires them.
+
+## Scope
+1. Core/package naming
+   - npm package name
+   - CLI/bin command name
+   - public SDK symbol names
+2. Runtime surfaces
+   - CLI help text and examples
+   - MCP tool names and server identity
+   - JSON-RPC proxy naming/messages
+   - server/API env var names
+3. Config surfaces
+   - env vars (`ASSAY_*`)
+   - config filenames (`assay.config.json`)
+   - default config paths (`~/.config/assay`)
+4. Documentation and schemas
+   - README + docs + architecture/audit/roadmap/research/plan docs
+   - schema docs and examples
+5. Tests and fixtures
+   - env var references
+   - helper and fixture naming
+   - expected text/assertions for renamed outputs
+
+## Execution steps
+1. Sweep and inventory all rename targets via repository-wide search.
+2. Apply full-case rename transforms for lowercase, title case, and upper-case surfaces.
+3. Fix collisions/regressions introduced by mechanical replacement.
+4. Run validation:
+   - `bun run check`
+   - `bun test`
+5. Commit + push + PR with explicit breaking-change note.
+
+## Compatibility policy
+- No compatibility aliases are retained in this pass by default.
+- If any alias must be retained to keep runtime/build green, it must be listed explicitly in PR notes with rationale.

--- a/docs/plans/issue-41-approval-diffs-engine.md
+++ b/docs/plans/issue-41-approval-diffs-engine.md
@@ -1,7 +1,7 @@
 # Issue #41 — Approval diffs engine (wallet-fast) — workflows plan
 
 ## Context
-Issue: https://github.com/marcomariscal/rugscan/issues/41
+Issue: #41
 
 Goal: make approval-change detection **trustworthy + fast** in wallet mode, across:
 - ERC-20 approvals (event + allowance diff)
@@ -153,7 +153,7 @@ No network calls; pure deterministic mocks.
 
 Practical options:
 - add wallet-mode contract test around `renderResultBox` using the recording fixture’s analysis payload.
-- add e2e fixture (`RUGSCAN_FORK_E2E=1`) for approval txs to verify integrated Anvil path.
+- add e2e fixture (`ASSAY_FORK_E2E=1`) for approval txs to verify integrated Anvil path.
 
 ## 4.3 Schema/contract tests
 Update tests that construct `BalanceSimulationResult` literals:

--- a/docs/plans/m4-approval-analysis.md
+++ b/docs/plans/m4-approval-analysis.md
@@ -24,7 +24,7 @@ If any of these assumptions are wrong, please confirm before implementation.
 ## Success Criteria
 - `analyzeApproval()` returns `ApprovalAnalysisResult` with flags and findings.
 - Each core detection feature triggers its specified finding codes.
-- `rugscan approval ...` works with or without context, produces clear output, and uses exit codes consistent with existing CLI behavior.
+- `assay approval ...` works with or without context, produces clear output, and uses exit codes consistent with existing CLI behavior.
 - Typosquat detection triggers only for “near misses,” not exact matches.
 
 ---
@@ -154,7 +154,7 @@ Optionally, extract the existing `KNOWN_PROTOCOL_ADDRESSES` from `defillama.ts` 
 ## 5. CLI Integration
 
 ### New subcommand
-`rugscan approval --token <addr> --spender <addr> --amount <value> [--expected <addr>] [--called <addr>] [--chain <chain>]`
+`assay approval --token <addr> --spender <addr> --amount <value> [--expected <addr>] [--called <addr>] [--chain <chain>]`
 
 Parsing:
 - `--amount max` → `MAX_UINT256`.
@@ -221,7 +221,7 @@ If you want strict TDD, I can reorder steps 2–5 to scaffold tests first.
 
 ## 9. Manual Verification Checklist
 
-- `rugscan approval --token 0xUSDC --spender <router> --amount max` → warns on unlimited.
+- `assay approval --token 0xUSDC --spender <router> --amount max` → warns on unlimited.
 - `--expected` mismatch triggers `APPROVAL_TARGET_MISMATCH`.
 - EOA spender triggers `APPROVAL_TO_EOA` + danger exit code.
 - Typosquat-like address triggers `POSSIBLE_TYPOSQUAT`.

--- a/docs/plans/m7-parallel-streaming.md
+++ b/docs/plans/m7-parallel-streaming.md
@@ -4,7 +4,7 @@
 - Parallelize independent provider calls to reduce total latency.
 - Stream findings to CLI as each provider completes.
 - Early exit on critical findings (KNOWN_PHISHING → abort remaining checks).
-- Add `rugscan analyze-tx <txHash>` for full call trace analysis.
+- Add `assay analyze-tx <txHash>` for full call trace analysis.
 - Cache analysis results to avoid re-checking the same contract.
 
 ## Non-Goals (explicit)
@@ -15,7 +15,7 @@
 ## Assumptions / Open Decisions
 - **Critical signal definition**: decide which provider fields map to `KNOWN_PHISHING` (GoPlus label, Etherscan label, custom list). If unclear, confirm and codify a single source of truth.
 - **Trace RPC method**: prefer `debug_traceTransaction` on geth-compatible RPC; if unavailable, we’ll return a clear error and skip trace analysis.
-- **Cache location**: default to a simple JSON file under a cache directory (e.g. `~/.cache/rugscan/analysis.json`), with in-memory fallback.
+- **Cache location**: default to a simple JSON file under a cache directory (e.g. `~/.cache/assay/analysis.json`), with in-memory fallback.
 - **Abort semantics**: we will attempt to cancel provider fetches via `AbortController`, but providers that don’t respect `signal` will be ignored once early-exit is triggered.
 - **Aggregate risk**: define whether to use `max`, `weighted average`, or `worst-N` for transaction-level scoring.
 
@@ -25,7 +25,7 @@ If any assumption is off, confirm before implementation.
 - Median end-to-end analysis latency drops meaningfully (e.g. ~2–3s → ~1–1.5s on typical RPC).
 - CLI shows per-provider progress and streams findings as they arrive.
 - When `KNOWN_PHISHING` is detected, remaining provider calls are aborted and the result returns immediately.
-- `rugscan analyze-tx` analyzes all contracts in a call trace and returns a per-contract breakdown + aggregate risk.
+- `assay analyze-tx` analyzes all contracts in a call trace and returns a per-contract breakdown + aggregate risk.
 - Cache hits skip provider calls and annotate output with `(cached)`.
 
 ---
@@ -190,7 +190,7 @@ cache?: {
 
 ---
 
-## 5. Call Trace Analysis (`rugscan analyze-tx`)
+## 5. Call Trace Analysis (`assay analyze-tx`)
 
 ### 5.1 New module
 Create `src/transaction.ts` (or `src/analyze-transaction.ts`) to encapsulate:
@@ -254,8 +254,8 @@ Update `src/cli/index.ts`:
 - Aggregate risk/recommendation derived correctly.
 
 ### 7.3 CLI smoke tests (optional)
-- `rugscan analyze <addr>` prints streaming output.
-- `rugscan analyze-tx <hash>` produces per-contract output.
+- `assay analyze <addr>` prints streaming output.
+- `assay analyze-tx <hash>` produces per-contract output.
 
 ---
 

--- a/docs/plans/m8-multi-interface.md
+++ b/docs/plans/m8-multi-interface.md
@@ -20,7 +20,7 @@
 If any assumption is off, confirm before implementation.
 
 ## Success Criteria
-- CLI: `rugscan scan --format json|sarif` emits valid structured output and predictable exit codes.
+- CLI: `assay scan --format json|sarif` emits valid structured output and predictable exit codes.
 - REST: `POST /v1/scan` returns `AnalyzeResponse` for both `address` and `calldata` inputs.
 - SDK: typed client wraps REST and exposes `scan()` with the same request/response models.
 - All interfaces use identical `ScanResult`/`AnalyzeResponse` definitions.
@@ -97,7 +97,7 @@ Notes:
 ## 2) CLI (format + exit codes)
 
 ### 2.1 Commands
-- `rugscan scan [address]` (existing or new entrypoint)
+- `assay scan [address]` (existing or new entrypoint)
 - Add `--calldata` to accept JSON string or file (see spec below).
 
 ### 2.2 CLI argument spec

--- a/docs/plans/m9-post-warm-anvil-latency-fix.md
+++ b/docs/plans/m9-post-warm-anvil-latency-fix.md
@@ -15,7 +15,7 @@ M9 is a set of *follow-ups* that make that latency work safer (regression covera
   - Output should match the existing `TxFixture` shape used by e2e suites under `test/fixtures/txs/*`.
 
 ## Non-Goals
-- Implementing a full `rugscan analyze-tx <txHash>` product surface (that’s a bigger feature; out of scope here).
+- Implementing a full `assay analyze-tx <txHash>` product surface (that’s a bigger feature; out of scope here).
 - Adding new simulation semantics beyond defaults/fixture generation.
 - Reworking the Anvil warm-reset design from PR #21.
 

--- a/docs/research/multi-interface-design.md
+++ b/docs/research/multi-interface-design.md
@@ -1,8 +1,8 @@
-# Multi-Interface Design Research for rugscan
+# Multi-Interface Design Research for assay
 Date: 2026-02-02
 
 ## Summary
-rugscan should expose one core analysis engine with four adapters: CLI, REST API, SDK, and MCP. Existing security tools are CLI-first with rich structured outputs (JSON/SARIF) and config files. Wallet-facing security engines emphasize fast pre-sign simulation, balance-change previews, and clear risk signals. Agent-friendly CLIs prioritize machine-readable output, deterministic exit codes, and stdin/stdout workflows.
+assay should expose one core analysis engine with four adapters: CLI, REST API, SDK, and MCP. Existing security tools are CLI-first with rich structured outputs (JSON/SARIF) and config files. Wallet-facing security engines emphasize fast pre-sign simulation, balance-change previews, and clear risk signals. Agent-friendly CLIs prioritize machine-readable output, deterministic exit codes, and stdin/stdout workflows.
 
 ## Research Findings
 
@@ -82,9 +82,9 @@ Common inputs in this space include:
 - MCP is an open protocol that lets AI apps connect to tools/resources and discover them at runtime. (Source: MCP Introduction)
 - MCP defines a tool discovery and invocation flow (`tools/list`, `tools/call`) via JSON-RPC, and it expects the client to control human-in-the-loop approval. (Source: MCP Tools spec)
 
-**Pattern to carry forward:** provide a rugscan MCP server that exposes primitive scan tools and returns rich structured output; keep workflow logic in the agent, not the tool.
+**Pattern to carry forward:** provide a assay MCP server that exposes primitive scan tools and returns rich structured output; keep workflow logic in the agent, not the tool.
 
-## Recommendations for rugscan
+## Recommendations for assay
 
 ### A) One core analysis engine + four adapters
 - **Core engine**: pure analysis that returns a stable `ScanResult` schema.

--- a/docs/research/post-scam-hooks.md
+++ b/docs/research/post-scam-hooks.md
@@ -1,9 +1,9 @@
 # Post-Scam Hooks & Agent Integration (Exploratory)
 
-Goal: define a post-scam hook system for Rugscan that triggers when a scam/rug is detected, routes signals to humans/agents, and feeds collective intelligence without leaking sensitive user data.
+Goal: define a post-scam hook system for Assay that triggers when a scam/rug is detected, routes signals to humans/agents, and feeds collective intelligence without leaking sensitive user data.
 
 ## Assumptions
-- Rugscan already produces pre-trade warnings and can classify post-trade outcomes.
+- Assay already produces pre-trade warnings and can classify post-trade outcomes.
 - "Post-scam" events should be evidence-backed and versioned to prevent noisy alerts.
 - Some integrations may require manual review or rate limits in early milestones.
 

--- a/docs/research/presign-ux-patterns.md
+++ b/docs/research/presign-ux-patterns.md
@@ -24,9 +24,9 @@ Notes:
 | Rainbow | Review screens focus on human-readable swap/bridge details (network, min received, fees, slippage, gas) with editable gas. | No raw data export mentioned in support docs. | Human-readable summary fields. | Rainbow support docs for swap/bridge review screens. |
 | Coinbase Wallet / Base app | Official docs emphasize network fee customization (max fee, priority fee, gas limit). | No raw data export mentioned in official docs. | Human-readable summary + gas fee customization. | Coinbase Help docs for adjusting network fees. |
 
-Implications for Rugscan:
+Implications for Assay:
 - Do not rely on wallets to give you a ready JSON export. Offer multiple input paths: raw hex, calldata + to/value, or JSON-RPC payload.
-- Provide a one-click "copy for Rugscan" in your own UI if you build a wallet plugin/extension.
+- Provide a one-click "copy for Assay" in your own UI if you build a wallet plugin/extension.
 
 ## 2) Existing pre-sign security tools
 
@@ -47,7 +47,7 @@ Notes:
 - `cast send` (Foundry) accepts raw hex data via `--data`, or ABI signature + args, with flags for `--rpc-url`, `--chain`, `--value`, gas options, etc. This is a clear multi-input model that favors flags and optional raw hex overrides.
 - `slither` is path-based (analyze a project or file) rather than transaction-input driven. Its CLI shows a "single command with options" pattern for security tooling, not JSON payloads.
 
-### Recommended CLI inputs for Rugscan
+### Recommended CLI inputs for Assay
 Support multiple formats and normalize internally to a single canonical schema:
 
 1) JSON (stdin or file)
@@ -66,9 +66,9 @@ Support multiple formats and normalize internally to a single canonical schema:
 - Optional: accept `--abi` + `--sig` + args, encode calldata internally.
 
 ### Ergonomics for wallet users
-- If a wallet exposes only raw hex calldata, allow: `rugscan --to 0x... --value 0 --data 0x... --chain-id 1`.
-- If a wallet exposes decoded ABI, allow: `rugscan --to 0x... --sig "approve(address,uint256)" 0xSpender 0xffff...`.
-- If a dapp can provide the JSON-RPC request, allow `rugscan --json` via stdin: `cat tx.json | rugscan --json`.
+- If a wallet exposes only raw hex calldata, allow: `assay --to 0x... --value 0 --data 0x... --chain-id 1`.
+- If a wallet exposes decoded ABI, allow: `assay --to 0x... --sig "approve(address,uint256)" 0xSpender 0xffff...`.
+- If a dapp can provide the JSON-RPC request, allow `assay --json` via stdin: `cat tx.json | assay --json`.
 
 ## 4) Browser extension vs RPC proxy vs wallet plugin
 

--- a/docs/simplification-plan.md
+++ b/docs/simplification-plan.md
@@ -1,4 +1,4 @@
-# Rugscan Simplification Plan
+# Assay Simplification Plan
 
 ## Assumptions
 - Primary product is a local CLI for quick contract checks.
@@ -71,7 +71,7 @@ Goal: one-line command, three-line output, clear severity.
 
 Command:
 ```
-rugscan check 0x...
+assay check 0x...
 ```
 
 Example outputs:
@@ -88,8 +88,8 @@ Behavior:
 - Optional flags: `--chain`, `--json` (if needed later).
 
 Notes:
-- Keep `rugscan approval` for explicit approval checks.
-- Remove `rugscan analyze`/`scan` once `check` exists.
+- Keep `assay approval` for explicit approval checks.
+- Remove `assay analyze`/`scan` once `check` exists.
 
 ## 99% Coverage (What's Missing)
 

--- a/docs/stable-json-output-v1.md
+++ b/docs/stable-json-output-v1.md
@@ -1,9 +1,9 @@
-# Stable JSON Output v1 (`rugscan scan --format json`)
+# Stable JSON Output v1 (`assay scan --format json`)
 
-This document defines a **stable, versioned** JSON contract intended for programmatic integrations (SDK/MCP/CI) consuming rugscan scan output.
+This document defines a **stable, versioned** JSON contract intended for programmatic integrations (SDK/MCP/CI) consuming assay scan output.
 
 Applies to:
-- `rugscan scan --format json`
+- `assay scan --format json`
 - the local server endpoint `POST /v1/scan`
 
 ## Contract

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-	"name": "rugscan",
+	"name": "assay",
 	"version": "0.1.0",
 	"description": "Pre-transaction security analysis for EVM contracts",
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"bin": {
-		"rugscan": "src/cli/index.ts",
 		"assay": "src/cli/index.ts"
 	},
 	"scripts": {

--- a/src/analyzer.ts
+++ b/src/analyzer.ts
@@ -160,7 +160,7 @@ export async function analyze(
 	const rpcUrl = config?.rpcUrls?.[chain];
 	if (offline && !rpcUrl) {
 		throw new Error(
-			`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in rugscan.config.json or ~/.config/rugscan/config.json)`,
+			`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in assay.config.json or ~/.config/assay/config.json)`,
 		);
 	}
 

--- a/src/approval.ts
+++ b/src/approval.ts
@@ -27,7 +27,7 @@ export async function analyzeApproval(
 	const rpcUrl = config?.rpcUrls?.[chain];
 	if (offline && !rpcUrl) {
 		throw new Error(
-			`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in rugscan.config.json or ~/.config/rugscan/config.json)`,
+			`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in assay.config.json or ~/.config/assay/config.json)`,
 		);
 	}
 

--- a/src/cli/formatters/sarif.ts
+++ b/src/cli/formatters/sarif.ts
@@ -39,7 +39,7 @@ export function formatSarif(response: AnalyzeResponse): SarifLog {
 			{
 				tool: {
 					driver: {
-						name: "rugscan",
+						name: "assay",
 						rules,
 					},
 				},

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,8 +13,8 @@ import { type CalldataInput, type ScanInput, scanInputSchema } from "../schema";
 import type { ApprovalContext, ApprovalTx, Chain, Recommendation } from "../types";
 import { formatSarif } from "./formatters/sarif";
 import {
+	ASSAY_UPSTREAM_ENV,
 	formatMissingUpstreamError,
-	RUGSCAN_UPSTREAM_ENV,
 	resolveProxyUpstreamUrl,
 } from "./proxy-upstream";
 import {
@@ -147,7 +147,7 @@ Options:
 
   Proxy:
   --upstream     Upstream JSON-RPC HTTP URL to forward requests to
-                 (default: $RUGSCAN_UPSTREAM or config rpcUrls.<chain>)
+                 (default: $ASSAY_UPSTREAM or config rpcUrls.<chain>)
   --save         Save --upstream to config file under rpcUrls.ethereum
   --hostname     Hostname to bind the proxy server (default: 127.0.0.1)
   --port         Port to bind the proxy server (default: 8545)
@@ -163,7 +163,7 @@ Options:
   --expected     Expected spender address
 
 Environment:
-  RUGSCAN_UPSTREAM        Default upstream JSON-RPC URL for rugscan proxy
+  ASSAY_UPSTREAM        Default upstream JSON-RPC URL for assay proxy
   ETHERSCAN_API_KEY       Etherscan API key (enables full analysis)
   BASESCAN_API_KEY        BaseScan API key
   ARBISCAN_API_KEY        Arbiscan API key
@@ -171,15 +171,15 @@ Environment:
   POLYGONSCAN_API_KEY     PolygonScan API key
 
 Examples:
-  rugscan analyze 0x1234...
-  rugscan analyze 0x1234... --chain base
-  rugscan scan 0x1234... --format json
+  assay analyze 0x1234...
+  assay analyze 0x1234... --chain base
+  assay scan 0x1234... --format json
   # Paste Rabby JSON directly
-  rugscan scan --calldata '{"chainId":1,"from":"0x...","to":"0x...","value":"0x0","data":"0x..."}' --format json
+  assay scan --calldata '{"chainId":1,"from":"0x...","to":"0x...","value":"0x0","data":"0x..."}' --format json
 
   # MetaMask "Hex Data" (raw calldata) + explicit target
-  rugscan scan --calldata 0x... --to 0x... --value 0x0 --chain 1 --format json
-  rugscan approval --token 0x1234... --spender 0xabcd... --amount max
+  assay scan --calldata 0x... --to 0x... --value 0x0 --chain 1 --format json
+  assay approval --token 0x1234... --spender 0xabcd... --amount max
 `);
 }
 
@@ -254,7 +254,7 @@ async function runAnalyze(args: string[]) {
 			if (!rpcUrl) {
 				console.error(
 					renderError(
-						`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in rugscan.config.json or ~/.config/rugscan/config.json)`,
+						`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in assay.config.json or ~/.config/assay/config.json)`,
 					),
 				);
 				process.exit(1);
@@ -361,7 +361,7 @@ async function runScan(args: string[]) {
 			if (!rpcUrl) {
 				console.error(
 					renderError(
-						`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in rugscan.config.json or ~/.config/rugscan/config.json)`,
+						`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in assay.config.json or ~/.config/assay/config.json)`,
 					),
 				);
 				process.exit(1);
@@ -506,7 +506,7 @@ async function runApproval(args: string[]) {
 			if (!rpcUrl) {
 				console.error(
 					renderError(
-						`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in rugscan.config.json or ~/.config/rugscan/config.json)`,
+						`offline mode: missing config rpcUrls.${chain} (no public RPC fallbacks; set it in assay.config.json or ~/.config/assay/config.json)`,
 					),
 				);
 				process.exit(1);
@@ -574,7 +574,7 @@ async function runProxy(args: string[]) {
 		cliUpstream,
 		chainArg: chain,
 		config,
-		envUpstream: process.env[RUGSCAN_UPSTREAM_ENV],
+		envUpstream: process.env[ASSAY_UPSTREAM_ENV],
 	});
 	if (!resolved) {
 		console.error(renderError(formatMissingUpstreamError({ chainArg: chain })));
@@ -666,7 +666,7 @@ async function runProxy(args: string[]) {
 async function runMcp(args: string[]) {
 	if (args.includes("--help") || args.includes("-h")) {
 		console.log(
-			"assay mcp - MCP server over stdio (Model Context Protocol)\n\nUsage:\n  assay mcp\n\nNotes:\n  - Communicates over stdin/stdout using JSON-RPC framing (Content-Length).\n  - Exposes Rugscan analysis as MCP tools.\n",
+			"assay mcp - MCP server over stdio (Model Context Protocol)\n\nUsage:\n  assay mcp\n\nNotes:\n  - Communicates over stdin/stdout using JSON-RPC framing (Content-Length).\n  - Exposes Assay analysis as MCP tools.\n",
 		);
 		process.exit(0);
 	}

--- a/src/cli/proxy-upstream.ts
+++ b/src/cli/proxy-upstream.ts
@@ -2,7 +2,7 @@ import { resolveUserConfigPathForWrite } from "../config";
 import { resolveScanChain } from "../scan";
 import type { Chain, Config } from "../types";
 
-export const RUGSCAN_UPSTREAM_ENV = "RUGSCAN_UPSTREAM";
+export const ASSAY_UPSTREAM_ENV = "ASSAY_UPSTREAM";
 
 export type UpstreamSource = "cli" | "env" | "config";
 
@@ -60,9 +60,9 @@ export function formatMissingUpstreamError(options: { chainArg: string | undefin
 		"",
 		"Set it using one of:",
 		"  1) CLI flag:",
-		"     rugscan proxy --upstream https://your-rpc.example",
+		"     assay proxy --upstream https://your-rpc.example",
 		"  2) Environment variable:",
-		`     export ${RUGSCAN_UPSTREAM_ENV}=https://your-rpc.example`,
+		`     export ${ASSAY_UPSTREAM_ENV}=https://your-rpc.example`,
 		"  3) Config file:",
 		`     ${configPath}`,
 		`     { "rpcUrls": { "${chainKey}": "https://your-rpc.example" } }`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,15 +6,10 @@ import type { AllowlistConfig, Chain, Config, SimulationConfig } from "./types";
 
 const VALID_CHAINS: Chain[] = ["ethereum", "base", "arbitrum", "optimism", "polygon"];
 
-export const DEFAULT_USER_CONFIG_PATH = path.join(
-	os.homedir(),
-	".config",
-	"rugscan",
-	"config.json",
-);
+export const DEFAULT_USER_CONFIG_PATH = path.join(os.homedir(), ".config", "assay", "config.json");
 
 const DEFAULT_CONFIG_PATHS = [
-	path.resolve(process.cwd(), "rugscan.config.json"),
+	path.resolve(process.cwd(), "assay.config.json"),
 	DEFAULT_USER_CONFIG_PATH,
 ];
 
@@ -27,7 +22,7 @@ export async function loadConfig(): Promise<Config> {
 
 export function resolveUserConfigPathForWrite(): string {
 	// Allow tests and power-users to redirect the config path.
-	const explicitPath = process.env.RUGSCAN_CONFIG;
+	const explicitPath = process.env.ASSAY_CONFIG;
 	return explicitPath && explicitPath.trim().length > 0 ? explicitPath : DEFAULT_USER_CONFIG_PATH;
 }
 
@@ -49,7 +44,7 @@ export async function saveRpcUrl(options: { chain: Chain; rpcUrl: string }): Pro
 }
 
 function resolveConfigPath(): string | undefined {
-	const explicitPath = process.env.RUGSCAN_CONFIG;
+	const explicitPath = process.env.ASSAY_CONFIG;
 	if (explicitPath) {
 		if (!existsSync(explicitPath)) {
 			throw new Error(`Config file not found at ${explicitPath}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,11 @@ export type {
 } from "./schema";
 export { ScanError, scan, scanAddress, scanCalldata } from "./sdk";
 export {
-	createRugscanViemTransport,
-	RugscanTransportError,
-	type RugscanTransportErrorReason,
-	type RugscanViemOnRisk,
-	type RugscanViemTransportOptions,
+	AssayTransportError,
+	type AssayTransportErrorReason,
+	type AssayViemOnRisk,
+	type AssayViemTransportOptions,
+	createAssayViemTransport,
 } from "./sdk/viem";
 export type {
 	AnalysisResult,

--- a/src/jsonrpc/proxy.ts
+++ b/src/jsonrpc/proxy.ts
@@ -710,7 +710,7 @@ export function createJsonRpcProxyServer(options: ProxyOptions) {
 				return new Response(null, { status: 204, headers: corsHeaders() });
 			}
 			if (request.method === "GET") {
-				return jsonResponse({ ok: true, name: "rugscan-jsonrpc-proxy" }, 200);
+				return jsonResponse({ ok: true, name: "assay-jsonrpc-proxy" }, 200);
 			}
 			if (request.method !== "POST") {
 				return jsonResponse(jsonRpcError(null, -32601, "Method not allowed"), 405);
@@ -930,7 +930,7 @@ export function createJsonRpcProxyServer(options: ProxyOptions) {
 							return jsonRpcError(
 								id,
 								4001,
-								"Transaction blocked by rugscan",
+								"Transaction blocked by assay",
 								buildProxyBlockData(outcome, allowlist),
 							);
 						}
@@ -943,7 +943,7 @@ export function createJsonRpcProxyServer(options: ProxyOptions) {
 						: jsonRpcError(
 								id,
 								4001,
-								"Transaction blocked by rugscan",
+								"Transaction blocked by assay",
 								buildProxyBlockData(outcome, allowlist),
 							);
 				}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -85,7 +85,7 @@ const analyzeAddressArgsSchema = z
 	.strict();
 
 function resolveStubDepsFromEnv(): AnalyzerDeps | null {
-	if (process.env.RUGSCAN_MCP_STUB_DEPS !== "1") return null;
+	if (process.env.ASSAY_MCP_STUB_DEPS !== "1") return null;
 
 	return {
 		ai: {
@@ -122,7 +122,7 @@ function resolveStubDepsFromEnv(): AnalyzerDeps | null {
 function toolList() {
 	return [
 		{
-			name: "rugscan.analyzeTransaction",
+			name: "assay.analyzeTransaction",
 			description: "Analyze an EVM transaction target + calldata for risk findings.",
 			inputSchema: {
 				type: "object",
@@ -143,7 +143,7 @@ function toolList() {
 			},
 		},
 		{
-			name: "rugscan.analyzeAddress",
+			name: "assay.analyzeAddress",
 			description: "Analyze a contract/address for risk findings.",
 			inputSchema: {
 				type: "object",
@@ -218,7 +218,7 @@ export async function runMcpServer(): Promise<void> {
 					const result = {
 						protocolVersion: "2024-11-05",
 						capabilities: { tools: {} },
-						serverInfo: { name: "rugscan", version: "0.1.0" },
+						serverInfo: { name: "assay", version: "0.1.0" },
 					};
 					send(jsonRpcResult(id, result));
 					return;
@@ -247,7 +247,7 @@ export async function runMcpServer(): Promise<void> {
 
 					const args = message.params.arguments;
 
-					if (name === "rugscan.analyzeTransaction") {
+					if (name === "assay.analyzeTransaction") {
 						const parsed = analyzeTransactionArgsSchema.safeParse(args);
 						if (!parsed.success) {
 							send(
@@ -308,7 +308,7 @@ export async function runMcpServer(): Promise<void> {
 						return;
 					}
 
-					if (name === "rugscan.analyzeAddress") {
+					if (name === "assay.analyzeAddress") {
 						const parsed = analyzeAddressArgsSchema.safeParse(args);
 						if (!parsed.success) {
 							send(
@@ -365,7 +365,7 @@ export async function runMcpServer(): Promise<void> {
 		},
 		onParseError: (error) => {
 			const message = error instanceof Error ? error.message : String(error);
-			process.stderr.write(`rugscan mcp parse error: ${message}\n`);
+			process.stderr.write(`assay mcp parse error: ${message}\n`);
 		},
 	});
 }

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -3,8 +3,8 @@ import { analyzeCalldata } from "./analyzers/calldata";
 import { buildIntent } from "./intent";
 import {
 	type AnalyzeResponse,
+	ASSAY_SCHEMA_VERSION,
 	type ContractInfo,
-	RUGSCAN_SCHEMA_VERSION,
 	type BalanceSimulationResult as ScanBalanceSimulationResult,
 	type ScanFinding,
 	type ScanInput,
@@ -154,7 +154,7 @@ export function buildAnalyzeResponse(
 	requestId?: string,
 ): AnalyzeResponse {
 	return {
-		schemaVersion: RUGSCAN_SCHEMA_VERSION,
+		schemaVersion: ASSAY_SCHEMA_VERSION,
 		requestId: requestId ?? crypto.randomUUID(),
 		scan: buildScanResult(input, analysis),
 	};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -2,9 +2,9 @@ import { z } from "zod";
 import type { Recommendation as BaseRecommendation } from "./types";
 
 /**
- * Stable JSON schema version for `rugscan scan --format json` and `POST /v1/scan`.
+ * Stable JSON schema version for `assay scan --format json` and `POST /v1/scan`.
  */
-export const RUGSCAN_SCHEMA_VERSION: 1 = 1;
+export const ASSAY_SCHEMA_VERSION: 1 = 1;
 
 export type Recommendation = BaseRecommendation;
 
@@ -227,7 +227,7 @@ export const scanResultSchema = z
 
 export const analyzeResponseSchema = z
 	.object({
-		schemaVersion: z.literal(RUGSCAN_SCHEMA_VERSION).optional().default(RUGSCAN_SCHEMA_VERSION),
+		schemaVersion: z.literal(ASSAY_SCHEMA_VERSION).optional().default(ASSAY_SCHEMA_VERSION),
 		requestId: z.string().uuid(),
 		scan: scanResultSchema,
 	})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -14,7 +14,7 @@ export interface ServerOptions {
 }
 
 export function createScanHandler(options: ServerOptions = {}) {
-	const apiKey = options.apiKey ?? process.env.RUGSCAN_API_KEY;
+	const apiKey = options.apiKey ?? process.env.ASSAY_API_KEY;
 	const scanFn = options.scanFn ?? scan;
 	const configPromise = options.config ? Promise.resolve(options.config) : loadConfig();
 

--- a/test/analyzer.test.ts
+++ b/test/analyzer.test.ts
@@ -1,10 +1,10 @@
 import { test as bunTest, describe, expect } from "bun:test";
 import { analyze } from "../src/analyzer";
 
-const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 /**
- * rugscan analyzer tests
+ * assay analyzer tests
  *
  * These tests verify real-world contracts produce expected findings.
  * They hit live APIs (Sourcify, GoPlus) so results are authentic.

--- a/test/approvals-fixture-e2e.test.ts
+++ b/test/approvals-fixture-e2e.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
@@ -84,7 +84,7 @@ async function runScanForFixture(fixture: TxFixture) {
 
 	const configPath = path.join(
 		os.tmpdir(),
-		`rugscan-test-sim-${fixture.txHash.slice(0, 10)}-${Date.now()}.json`,
+		`assay-test-sim-${fixture.txHash.slice(0, 10)}-${Date.now()}.json`,
 	);
 	await Bun.write(
 		configPath,
@@ -94,7 +94,7 @@ async function runScanForFixture(fixture: TxFixture) {
 	const result = await runCli(
 		["scan", "--calldata", calldata, "--format", "json", "--fail-on", "danger", "--quiet"],
 		{
-			RUGSCAN_CONFIG: configPath,
+			ASSAY_CONFIG: configPath,
 			NO_COLOR: "1",
 			PATH: `${anvilDir}:${bunDir}:${process.env.PATH ?? ""}`,
 		},

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import { test as bunTest, describe, expect } from "bun:test";
 
-const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 async function runCli(args: string[], envOverrides: Record<string, string | undefined> = {}) {
 	const env = { ...process.env, ...envOverrides };

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -14,7 +14,7 @@ function setEnv(key: string, value: string | undefined) {
 
 describe("config", () => {
 	test("env overrides config file etherscan key", async () => {
-		const tempPath = path.join(os.tmpdir(), `rugscan-config-${Date.now()}.json`);
+		const tempPath = path.join(os.tmpdir(), `assay-config-${Date.now()}.json`);
 		await writeFile(
 			tempPath,
 			JSON.stringify({
@@ -25,18 +25,18 @@ describe("config", () => {
 		);
 
 		const previous = {
-			RUGSCAN_CONFIG: process.env.RUGSCAN_CONFIG,
+			ASSAY_CONFIG: process.env.ASSAY_CONFIG,
 			ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY,
 		};
 
 		try {
-			setEnv("RUGSCAN_CONFIG", tempPath);
+			setEnv("ASSAY_CONFIG", tempPath);
 			setEnv("ETHERSCAN_API_KEY", "env-key");
 
 			const config = await loadConfig();
 			expect(config.etherscanKeys?.ethereum).toBe("env-key");
 		} finally {
-			setEnv("RUGSCAN_CONFIG", previous.RUGSCAN_CONFIG);
+			setEnv("ASSAY_CONFIG", previous.ASSAY_CONFIG);
 			setEnv("ETHERSCAN_API_KEY", previous.ETHERSCAN_API_KEY);
 			await rm(tempPath, { force: true });
 		}

--- a/test/evals/balancer-rounding-2025/eval.test.ts
+++ b/test/evals/balancer-rounding-2025/eval.test.ts
@@ -8,7 +8,7 @@ import { join } from "node:path";
 /**
  * Balancer V2 Rounding Error Exploit Eval
  *
- * This eval tests whether rugscan would have detected the vulnerability
+ * This eval tests whether assay would have detected the vulnerability
  * that led to $128M being drained on November 3, 2025.
  *
  * The exploit leveraged precision loss in _upscaleArray's mulDown operation

--- a/test/fixtures/scan-sarif.json
+++ b/test/fixtures/scan-sarif.json
@@ -5,7 +5,7 @@
 		{
 			"tool": {
 				"driver": {
-					"name": "rugscan",
+					"name": "assay",
 					"rules": [
 						{
 							"id": "UNVERIFIED",

--- a/test/helpers/routerSwapFixtures.ts
+++ b/test/helpers/routerSwapFixtures.ts
@@ -66,7 +66,7 @@ async function runOnce(options: {
 	rpcUrl: string;
 	anvilPath: string;
 }): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-	const tmpDir = await mkdtemp(path.join(os.tmpdir(), "rugscan-e2e-"));
+	const tmpDir = await mkdtemp(path.join(os.tmpdir(), "assay-e2e-"));
 	const configPath = path.join(tmpDir, "config.json");
 	await writeFile(
 		configPath,
@@ -95,7 +95,7 @@ async function runOnce(options: {
 	const args = ["scan", "--calldata", calldata, "--format", options.format, "--quiet"];
 	const env = {
 		...process.env,
-		RUGSCAN_CONFIG: configPath,
+		ASSAY_CONFIG: configPath,
 		NO_COLOR: "1",
 	};
 
@@ -110,18 +110,18 @@ async function runOnce(options: {
 	return { exitCode, stdout, stderr };
 }
 
-export async function runRugscanScanWithTempForkConfig(options: {
+export async function runAssayScanWithTempForkConfig(options: {
 	fixture: TxFixture;
 	format?: "json";
 }): Promise<{ exitCode: number; stdout: string; stderr: string }> {
 	const anvilPath =
-		process.env.RUGSCAN_ANVIL_PATH ?? path.join(os.homedir(), ".foundry", "bin", "anvil");
+		process.env.ASSAY_ANVIL_PATH ?? path.join(os.homedir(), ".foundry", "bin", "anvil");
 	if (!existsSync(anvilPath)) {
 		throw new Error(`Anvil not found at ${anvilPath}`);
 	}
 
-	const rpcUrls = process.env.RUGSCAN_TEST_RPC_URL
-		? [process.env.RUGSCAN_TEST_RPC_URL]
+	const rpcUrls = process.env.ASSAY_TEST_RPC_URL
+		? [process.env.ASSAY_TEST_RPC_URL]
 		: ["https://eth.drpc.org", "https://ethereum.publicnode.com", "https://eth.llamarpc.com"];
 
 	let lastResult: { exitCode: number; stdout: string; stderr: string } | null = null;

--- a/test/jsonrpc-proxy.recording.test.ts
+++ b/test/jsonrpc-proxy.recording.test.ts
@@ -12,7 +12,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 describe("jsonrpc proxy - recording", () => {
 	test("writes a recording bundle when recordDir is set", async () => {
-		const recordDir = path.join(os.tmpdir(), `rugscan-proxy-record-${Date.now()}`);
+		const recordDir = path.join(os.tmpdir(), `assay-proxy-record-${Date.now()}`);
 
 		const upstreamSeen: unknown[] = [];
 		const upstream = Bun.serve({

--- a/test/mcp.unit.test.ts
+++ b/test/mcp.unit.test.ts
@@ -71,8 +71,8 @@ describe("mcp server (unit)", () => {
 			stderr: "pipe",
 			env: {
 				...process.env,
-				RUGSCAN_MCP_STUB_DEPS: "1",
-				RUGSCAN_CONFIG: "test/fixtures/empty-config.json",
+				ASSAY_MCP_STUB_DEPS: "1",
+				ASSAY_CONFIG: "test/fixtures/empty-config.json",
 			},
 		});
 
@@ -126,7 +126,7 @@ describe("mcp server (unit)", () => {
 					method: "initialize",
 					params: {
 						protocolVersion: "2024-11-05",
-						clientInfo: { name: "rugscan-test", version: "0" },
+						clientInfo: { name: "assay-test", version: "0" },
 						capabilities: {},
 					},
 				}),
@@ -143,7 +143,7 @@ describe("mcp server (unit)", () => {
 				}),
 			);
 			const list = await readMessage(reader);
-			expect(JSON.stringify(list)).toContain("rugscan.analyzeTransaction");
+			expect(JSON.stringify(list)).toContain("assay.analyzeTransaction");
 
 			await writeStdin(
 				encodeMessage({
@@ -151,7 +151,7 @@ describe("mcp server (unit)", () => {
 					id: 3,
 					method: "tools/call",
 					params: {
-						name: "rugscan.analyzeTransaction",
+						name: "assay.analyzeTransaction",
 						arguments: {
 							chain: "ethereum",
 							to: "0x66a9893cc07d91d95644aedd05d03f95e1dba8af",
@@ -198,8 +198,8 @@ describe("mcp server (unit)", () => {
 			stderr: "pipe",
 			env: {
 				...process.env,
-				RUGSCAN_MCP_STUB_DEPS: "1",
-				RUGSCAN_CONFIG: "test/fixtures/empty-config.json",
+				ASSAY_MCP_STUB_DEPS: "1",
+				ASSAY_CONFIG: "test/fixtures/empty-config.json",
 			},
 		});
 
@@ -253,7 +253,7 @@ describe("mcp server (unit)", () => {
 					method: "initialize",
 					params: {
 						protocolVersion: "2024-11-05",
-						clientInfo: { name: "rugscan-test", version: "0" },
+						clientInfo: { name: "assay-test", version: "0" },
 						capabilities: {},
 					},
 				}),
@@ -267,7 +267,7 @@ describe("mcp server (unit)", () => {
 					method: "initialize",
 					params: {
 						protocolVersion: "2024-11-05",
-						clientInfo: { name: "rugscan-test", version: "0" },
+						clientInfo: { name: "assay-test", version: "0" },
 						capabilities: {},
 					},
 				}),
@@ -306,8 +306,8 @@ describe("mcp server (unit)", () => {
 			stderr: "pipe",
 			env: {
 				...process.env,
-				RUGSCAN_MCP_STUB_DEPS: "1",
-				RUGSCAN_CONFIG: "test/fixtures/empty-config.json",
+				ASSAY_MCP_STUB_DEPS: "1",
+				ASSAY_CONFIG: "test/fixtures/empty-config.json",
 			},
 		});
 
@@ -360,7 +360,7 @@ describe("mcp server (unit)", () => {
 					id: 1,
 					method: "tools/call",
 					params: {
-						name: "rugscan.analyzeTransaction",
+						name: "assay.analyzeTransaction",
 						arguments: {
 							chain: "ethereum",
 							// missing required fields like to/data
@@ -377,7 +377,7 @@ describe("mcp server (unit)", () => {
 			expect(error.message).toBe("Invalid tool arguments");
 			const data = error.data;
 			if (!isRecord(data)) throw new Error("Expected MCP error.data to be an object");
-			expect(data.tool).toBe("rugscan.analyzeTransaction");
+			expect(data.tool).toBe("assay.analyzeTransaction");
 			expect(Array.isArray(data.issues)).toBe(true);
 		} finally {
 			if (webWriter) {

--- a/test/offline-rpc-only.no-http.test.ts
+++ b/test/offline-rpc-only.no-http.test.ts
@@ -118,7 +118,7 @@ function handleJsonRpc(req: JsonRpcRequest): unknown {
 		return { jsonrpc: "2.0", id, result: "0x1" };
 	}
 	if (method === "eth_getCode") {
-		// Non-empty bytecode so rugscan treats it as a contract.
+		// Non-empty bytecode so assay treats it as a contract.
 		return { jsonrpc: "2.0", id, result: "0x60006000" };
 	}
 	if (method === "eth_getStorageAt") {

--- a/test/providers/defillama.test.ts
+++ b/test/providers/defillama.test.ts
@@ -1,7 +1,7 @@
 import { test as bunTest, describe, expect } from "bun:test";
 import { matchProtocol } from "../../src/providers/defillama";
 
-const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("defillama", () => {
 	test("matchProtocol identifies Uniswap", async () => {

--- a/test/providers/goplus.test.ts
+++ b/test/providers/goplus.test.ts
@@ -1,7 +1,7 @@
 import { test as bunTest, describe, expect } from "bun:test";
 import { getTokenSecurity } from "../../src/providers/goplus";
 
-const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("goplus", () => {
 	test("getTokenSecurity flags honeypot tokens", async () => {

--- a/test/providers/proxy.test.ts
+++ b/test/providers/proxy.test.ts
@@ -1,7 +1,7 @@
 import { test as bunTest, describe, expect } from "bun:test";
 import { detectProxy } from "../../src/providers/proxy";
 
-const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("proxy detection", () => {
 	test("detectProxy identifies EIP-1967 proxies (USDC)", async () => {

--- a/test/providers/sourcify.test.ts
+++ b/test/providers/sourcify.test.ts
@@ -1,7 +1,7 @@
 import { test as bunTest, describe, expect } from "bun:test";
 import { checkVerification } from "../../src/providers/sourcify";
 
-const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 describe("sourcify", () => {
 	test("checkVerification returns verified contract metadata", async () => {

--- a/test/proxy-upstream.test.ts
+++ b/test/proxy-upstream.test.ts
@@ -3,8 +3,8 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+	ASSAY_UPSTREAM_ENV,
 	formatMissingUpstreamError,
-	RUGSCAN_UPSTREAM_ENV,
 	resolveProxyUpstreamUrl,
 } from "../src/cli/proxy-upstream";
 import { saveRpcUrl } from "../src/config";
@@ -17,7 +17,7 @@ function setEnv(key: string, value: string | undefined) {
 	process.env[key] = value;
 }
 
-describe("rugscan proxy upstream", () => {
+describe("assay proxy upstream", () => {
 	test("resolution order: cli > env > config", () => {
 		const config = {
 			rpcUrls: {
@@ -54,36 +54,36 @@ describe("rugscan proxy upstream", () => {
 	});
 
 	test("missing upstream error message shows env var + config path", async () => {
-		const tempDir = await mkdtemp(path.join(os.tmpdir(), "rugscan-upstream-"));
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "assay-upstream-"));
 		const tempConfigPath = path.join(tempDir, "config.json");
 
 		const previous = {
-			RUGSCAN_CONFIG: process.env.RUGSCAN_CONFIG,
+			ASSAY_CONFIG: process.env.ASSAY_CONFIG,
 		};
 
 		try {
-			setEnv("RUGSCAN_CONFIG", tempConfigPath);
+			setEnv("ASSAY_CONFIG", tempConfigPath);
 
 			const message = formatMissingUpstreamError({ chainArg: "ethereum" });
-			expect(message).toContain(RUGSCAN_UPSTREAM_ENV);
+			expect(message).toContain(ASSAY_UPSTREAM_ENV);
 			expect(message).toContain(tempConfigPath);
 			expect(message).toContain("rpcUrls");
 		} finally {
-			setEnv("RUGSCAN_CONFIG", previous.RUGSCAN_CONFIG);
+			setEnv("ASSAY_CONFIG", previous.ASSAY_CONFIG);
 			await rm(tempDir, { recursive: true, force: true });
 		}
 	});
 
 	test("--save persists rpcUrls.ethereum without clobbering other keys", async () => {
-		const tempDir = await mkdtemp(path.join(os.tmpdir(), "rugscan-save-"));
+		const tempDir = await mkdtemp(path.join(os.tmpdir(), "assay-save-"));
 		const tempConfigPath = path.join(tempDir, "config.json");
 
 		const previous = {
-			RUGSCAN_CONFIG: process.env.RUGSCAN_CONFIG,
+			ASSAY_CONFIG: process.env.ASSAY_CONFIG,
 		};
 
 		try {
-			setEnv("RUGSCAN_CONFIG", tempConfigPath);
+			setEnv("ASSAY_CONFIG", tempConfigPath);
 
 			await writeFile(
 				tempConfigPath,
@@ -123,7 +123,7 @@ describe("rugscan proxy upstream", () => {
 
 			expect(rpcUrls.ethereum).toBe("https://new-eth.example");
 		} finally {
-			setEnv("RUGSCAN_CONFIG", previous.RUGSCAN_CONFIG);
+			setEnv("ASSAY_CONFIG", previous.ASSAY_CONFIG);
 			await rm(tempDir, { recursive: true, force: true });
 		}
 	});

--- a/test/scan-cli.test.ts
+++ b/test/scan-cli.test.ts
@@ -1,6 +1,6 @@
 import { test as bunTest, describe, expect } from "bun:test";
 
-const test = process.env.RUGSCAN_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_LIVE_TESTS === "1" ? bunTest : bunTest.skip;
 
 async function runCli(args: string[], envOverrides: Record<string, string | undefined> = {}) {
 	const env = { ...process.env, ...envOverrides };

--- a/test/simulation-e2e.test.ts
+++ b/test/simulation-e2e.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 async function runCli(args: string[], envOverrides: Record<string, string | undefined> = {}) {
 	const env = { ...process.env, ...envOverrides };
@@ -27,7 +27,7 @@ function stripAnsi(input: string): string {
 const configPath = fileURLToPath(new URL("./fixtures/simulation-config.json", import.meta.url));
 const emptyConfigPath = fileURLToPath(new URL("./fixtures/empty-config.json", import.meta.url));
 const anvilPath =
-	process.env.RUGSCAN_ANVIL_PATH ?? path.join(os.homedir(), ".foundry", "bin", "anvil");
+	process.env.ASSAY_ANVIL_PATH ?? path.join(os.homedir(), ".foundry", "bin", "anvil");
 const anvilDir = path.dirname(anvilPath);
 const foundryDefaultAnvilPath = path.join(os.homedir(), ".foundry", "bin", "anvil");
 const bunDir = path.dirname(process.execPath);
@@ -42,7 +42,7 @@ const calldata = JSON.stringify({
 
 function baseEnv(config: string) {
 	return {
-		RUGSCAN_CONFIG: config,
+		ASSAY_CONFIG: config,
 		NO_COLOR: "1",
 		PATH: `${anvilDir}:${process.env.PATH ?? ""}`,
 	};
@@ -50,7 +50,7 @@ function baseEnv(config: string) {
 
 function envWithoutAnvilOnPath(config: string) {
 	return {
-		RUGSCAN_CONFIG: config,
+		ASSAY_CONFIG: config,
 		NO_COLOR: "1",
 		PATH: bunDir,
 	};

--- a/test/simulation-lend-borrow-fixtures-e2e.test.ts
+++ b/test/simulation-lend-borrow-fixtures-e2e.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
@@ -149,7 +149,7 @@ describe("lend/borrow simulation fixtures e2e", () => {
 			const result = await runCli(
 				["scan", "--calldata", calldata, "--format", "json", "--fail-on", "danger", "--quiet"],
 				{
-					RUGSCAN_CONFIG: fixture.configPath,
+					ASSAY_CONFIG: fixture.configPath,
 					NO_COLOR: "1",
 					PATH: bunDir,
 				},

--- a/test/simulation-router-swap-fixtures-e2e.test.ts
+++ b/test/simulation-router-swap-fixtures-e2e.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
 	isTxFixture,
-	runRugscanScanWithTempForkConfig,
+	runAssayScanWithTempForkConfig,
 	type TxFixture,
 } from "./helpers/routerSwapFixtures";
 
@@ -19,8 +19,8 @@ function isSimulationResult(value: unknown): value is Record<string, unknown> {
 
 const fixturesDir = fileURLToPath(new URL("./fixtures/txs", import.meta.url));
 const anvilPath =
-	process.env.RUGSCAN_ANVIL_PATH ?? path.join(os.homedir(), ".foundry", "bin", "anvil");
-const forkE2E = process.env.RUGSCAN_FORK_E2E === "1";
+	process.env.ASSAY_ANVIL_PATH ?? path.join(os.homedir(), ".foundry", "bin", "anvil");
+const forkE2E = process.env.ASSAY_FORK_E2E === "1";
 
 const fixtureFiles = readdirSync(fixturesDir)
 	.filter((file) => file.endsWith(".json"))
@@ -46,7 +46,7 @@ describe("router swap fixtures e2e", () => {
 			`${fileName} simulates successfully`,
 			async () => {
 				const fixture = await loadFixture(fileName);
-				const result = await runRugscanScanWithTempForkConfig({ fixture, format: "json" });
+				const result = await runAssayScanWithTempForkConfig({ fixture, format: "json" });
 
 				expect(result.exitCode).toBe(0);
 
@@ -56,7 +56,7 @@ describe("router swap fixtures e2e", () => {
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);
 					throw new Error(
-						`Failed to parse rugscan JSON output (${fixture.name}): ${message}\n` +
+						`Failed to parse assay JSON output (${fixture.name}): ${message}\n` +
 							`stdout:\n${result.stdout}\n` +
 							`stderr:\n${result.stderr}\n`,
 					);

--- a/test/simulation-unavailable.test.ts
+++ b/test/simulation-unavailable.test.ts
@@ -34,7 +34,7 @@ describe("simulateBalance", () => {
 		const originalHome = process.env.HOME;
 		const originalPath = process.env.PATH;
 
-		const tmpHome = mkdtempSync(path.join(os.tmpdir(), "rugscan-home-"));
+		const tmpHome = mkdtempSync(path.join(os.tmpdir(), "assay-home-"));
 		process.env.HOME = tmpHome;
 		process.env.PATH = tmpHome;
 

--- a/test/simulation-universalrouter-fixture-e2e.test.ts
+++ b/test/simulation-universalrouter-fixture-e2e.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const test = process.env.RUGSCAN_FORK_E2E === "1" ? bunTest : bunTest.skip;
+const test = process.env.ASSAY_FORK_E2E === "1" ? bunTest : bunTest.skip;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
@@ -50,7 +50,7 @@ describe("simulation fixture e2e", () => {
 		const result = await runCli(
 			["scan", "--calldata", calldata, "--format", "json", "--fail-on", "danger", "--quiet"],
 			{
-				RUGSCAN_CONFIG: forkConfigPath,
+				ASSAY_CONFIG: forkConfigPath,
 				NO_COLOR: "1",
 				PATH: bunDir,
 			},

--- a/test/viem-transport.unit.test.ts
+++ b/test/viem-transport.unit.test.ts
@@ -4,11 +4,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains";
 import { buildAnalyzeResponse } from "../src/scan";
 import type { ScanInput } from "../src/schema";
-import {
-	createRugscanViemTransport,
-	type RugscanScanFn,
-	RugscanTransportError,
-} from "../src/sdk/viem";
+import { type AssayScanFn, AssayTransportError, createAssayViemTransport } from "../src/sdk/viem";
 import type { AnalysisResult, BalanceSimulationResult, Config, Recommendation } from "../src/types";
 
 function buildSimulation(success: boolean): BalanceSimulationResult {
@@ -62,13 +58,13 @@ describe("viem transport - unit", () => {
 		const { transport: upstream, calls } = createUpstream();
 		const config: Config = {};
 
-		const scanFn: RugscanScanFn = async (input: ScanInput, options) => {
+		const scanFn: AssayScanFn = async (input: ScanInput, options) => {
 			const analysis = buildAnalysis({ recommendation: "ok", simulationSuccess: false });
 			const response = buildAnalyzeResponse(input, analysis, options?.requestId);
 			return { analysis, response };
 		};
 
-		const transport = createRugscanViemTransport({
+		const transport = createAssayViemTransport({
 			upstream,
 			config,
 			threshold: "danger",
@@ -98,8 +94,8 @@ describe("viem transport - unit", () => {
 		}
 
 		expect(calls.length).toBe(0);
-		expect(error).toBeInstanceOf(RugscanTransportError);
-		if (!(error instanceof RugscanTransportError)) return;
+		expect(error).toBeInstanceOf(AssayTransportError);
+		if (!(error instanceof AssayTransportError)) return;
 		expect(error.reason).toBe("simulation_failed");
 		expect(error.analyzeResponse?.requestId).toBe("req-1");
 		expect(typeof error.renderedSummary).toBe("string");
@@ -109,13 +105,13 @@ describe("viem transport - unit", () => {
 		const { transport: upstream, calls } = createUpstream();
 		const config: Config = {};
 
-		const scanFn: RugscanScanFn = async (input: ScanInput, options) => {
+		const scanFn: AssayScanFn = async (input: ScanInput, options) => {
 			const analysis = buildAnalysis({ recommendation: "warning", simulationSuccess: true });
 			const response = buildAnalyzeResponse(input, analysis, options?.requestId);
 			return { analysis, response };
 		};
 
-		const transport = createRugscanViemTransport({
+		const transport = createAssayViemTransport({
 			upstream,
 			config,
 			threshold: "warning",
@@ -136,7 +132,7 @@ describe("viem transport - unit", () => {
 					},
 				],
 			}),
-		).rejects.toBeInstanceOf(RugscanTransportError);
+		).rejects.toBeInstanceOf(AssayTransportError);
 
 		expect(calls.length).toBe(0);
 	});
@@ -145,13 +141,13 @@ describe("viem transport - unit", () => {
 		const { transport: upstream, calls } = createUpstream();
 		const config: Config = {};
 
-		const scanFn: RugscanScanFn = async (input: ScanInput, options) => {
+		const scanFn: AssayScanFn = async (input: ScanInput, options) => {
 			const analysis = buildAnalysis({ recommendation: "ok", simulationSuccess: true });
 			const response = buildAnalyzeResponse(input, analysis, options?.requestId);
 			return { analysis, response };
 		};
 
-		const transport = createRugscanViemTransport({
+		const transport = createAssayViemTransport({
 			upstream,
 			config,
 			threshold: "warning",
@@ -181,11 +177,11 @@ describe("viem transport - unit", () => {
 		const { transport: upstream, calls } = createUpstream();
 		const config: Config = {};
 
-		const scanFn: RugscanScanFn = async () => {
+		const scanFn: AssayScanFn = async () => {
 			throw new Error("boom");
 		};
 
-		const transport = createRugscanViemTransport({
+		const transport = createAssayViemTransport({
 			upstream,
 			config,
 			threshold: "warning",
@@ -206,7 +202,7 @@ describe("viem transport - unit", () => {
 					},
 				],
 			}),
-		).rejects.toBeInstanceOf(RugscanTransportError);
+		).rejects.toBeInstanceOf(AssayTransportError);
 
 		expect(calls.length).toBe(0);
 	});
@@ -228,7 +224,7 @@ describe("viem transport - unit", () => {
 			maxPriorityFeePerGas: 1n,
 		});
 
-		const scanFn: RugscanScanFn = async (input: ScanInput, options) => {
+		const scanFn: AssayScanFn = async (input: ScanInput, options) => {
 			expect(input.calldata?.to.toLowerCase()).toBe("0x66a9893cc07d91d95644aedd05d03f95e1dba8af");
 			expect(input.calldata?.from?.toLowerCase()).toBe(account.address.toLowerCase());
 			expect(input.calldata?.data).toBe("0x1234");
@@ -240,7 +236,7 @@ describe("viem transport - unit", () => {
 			return { analysis, response };
 		};
 
-		const transport = createRugscanViemTransport({
+		const transport = createAssayViemTransport({
 			upstream,
 			config,
 			threshold: "warning",


### PR DESCRIPTION
## Summary
This PR performs a comprehensive naming sweep to **Assay** across runtime, CLI/API surfaces, docs, tests, and tooling.

This PR **supersedes #54** by covering the full runtime/API/CLI/config/package scope.

## Breaking change (intentional)
This is an intentional **breaking rename** with **no backward-compat aliases** retained.

## Migration
### Canonical command/package surfaces
- CLI command: `assay ...`
- npm package import: `"assay"`
- package name: `assay`
- bin: `assay`

### Canonical env/config surfaces
- Env prefix: `ASSAY_*`
- Config file: `./assay.config.json`
- User config path: `~/.config/assay/config.json`

### Canonical SDK/runtime surfaces
- `createAssayViemTransport`
- `AssayTransportError`
- `AssayTransportErrorReason`
- `AssayViemOnRisk`
- `AssayViemTransportOptions`
- `AssayScanFn`
- `ASSAY_SCHEMA_VERSION`

### Canonical MCP naming
- `assay.analyzeTransaction`
- `assay.analyzeAddress`
- MCP server name: `assay`

## Scope included
- CLI help/output/examples
- API/server + MCP naming surfaces
- config/env + config path/filename surfaces
- package/bin identifiers
- runtime identifiers, docs, tests, fixtures, schema docs, workflow env references

## Compatibility aliases kept
- **None**

## Validation
- `bun run check` ✅
- `bun test` ✅