### PR TITLE
fix: use single ETHERSCAN_API_KEY as default for all chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,15 +156,14 @@ Tools exposed:
 
 ### Block Explorer Keys (optional, improves coverage)
 
+Etherscan V2 supports a single API key across Etherscan-family chains.
+Set `ETHERSCAN_API_KEY` once for all supported chains:
+
 ```bash
 export ETHERSCAN_API_KEY=your_key
-export BASESCAN_API_KEY=your_key
-export ARBISCAN_API_KEY=your_key
-export OPTIMISM_API_KEY=your_key
-export POLYGONSCAN_API_KEY=your_key
 ```
 
-Without keys, analysis uses Sourcify only.
+Without a key, analysis uses Sourcify only.
 
 ### Config File (alternative to env vars)
 
@@ -238,10 +237,10 @@ console.log(txResponse.scan.simulation?.approvals.changes);
 | Chain | Explorer Key Env Var |
 |-------|---------------------|
 | Ethereum | `ETHERSCAN_API_KEY` |
-| Base | `BASESCAN_API_KEY` |
-| Arbitrum | `ARBISCAN_API_KEY` |
-| Optimism | `OPTIMISM_API_KEY` |
-| Polygon | `POLYGONSCAN_API_KEY` |
+| Base | `ETHERSCAN_API_KEY` |
+| Arbitrum | `ETHERSCAN_API_KEY` |
+| Optimism | `ETHERSCAN_API_KEY` |
+| Polygon | `ETHERSCAN_API_KEY` |
 
 ## Finding Codes
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -163,12 +163,8 @@ Options:
   --expected     Expected spender address
 
 Environment:
-  ASSAY_UPSTREAM        Default upstream JSON-RPC URL for assay proxy
-  ETHERSCAN_API_KEY       Etherscan API key (enables full analysis)
-  BASESCAN_API_KEY        BaseScan API key
-  ARBISCAN_API_KEY        Arbiscan API key
-  OPTIMISM_API_KEY        Optimistic Etherscan API key
-  POLYGONSCAN_API_KEY     PolygonScan API key
+  ASSAY_UPSTREAM          Default upstream JSON-RPC URL for assay proxy
+  ETHERSCAN_API_KEY       Etherscan V2 API key (used across supported chains)
 
 Examples:
   assay analyze 0x1234...

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,10 +64,10 @@ function loadEnvConfig(): Config {
 	return {
 		etherscanKeys: {
 			ethereum: sharedEtherscanKey,
-			base: process.env.BASESCAN_API_KEY ?? sharedEtherscanKey,
-			arbitrum: process.env.ARBISCAN_API_KEY ?? sharedEtherscanKey,
-			optimism: process.env.OPTIMISM_API_KEY ?? sharedEtherscanKey,
-			polygon: process.env.POLYGONSCAN_API_KEY ?? sharedEtherscanKey,
+			base: sharedEtherscanKey,
+			arbitrum: sharedEtherscanKey,
+			optimism: sharedEtherscanKey,
+			polygon: sharedEtherscanKey,
 		},
 	};
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -42,26 +42,22 @@ describe("config", () => {
 		}
 	});
 
-	test("single ETHERSCAN_API_KEY is used as fallback for non-mainnet chains", async () => {
+	test("single ETHERSCAN_API_KEY is used for all supported chains", async () => {
 		const previous = {
 			ETHERSCAN_API_KEY: process.env.ETHERSCAN_API_KEY,
-			BASESCAN_API_KEY: process.env.BASESCAN_API_KEY,
-			ARBISCAN_API_KEY: process.env.ARBISCAN_API_KEY,
 		};
 
 		try {
 			setEnv("ETHERSCAN_API_KEY", "shared-key");
-			setEnv("BASESCAN_API_KEY", undefined);
-			setEnv("ARBISCAN_API_KEY", "arb-override");
 
 			const config = await loadConfig();
 			expect(config.etherscanKeys?.ethereum).toBe("shared-key");
 			expect(config.etherscanKeys?.base).toBe("shared-key");
-			expect(config.etherscanKeys?.arbitrum).toBe("arb-override");
+			expect(config.etherscanKeys?.arbitrum).toBe("shared-key");
+			expect(config.etherscanKeys?.optimism).toBe("shared-key");
+			expect(config.etherscanKeys?.polygon).toBe("shared-key");
 		} finally {
 			setEnv("ETHERSCAN_API_KEY", previous.ETHERSCAN_API_KEY);
-			setEnv("BASESCAN_API_KEY", previous.BASESCAN_API_KEY);
-			setEnv("ARBISCAN_API_KEY", previous.ARBISCAN_API_KEY);
 		}
 	});
 });


### PR DESCRIPTION
Makes Etherscan key handling graceful and simpler.

Changes:
- use ETHERSCAN_API_KEY for Ethereum, Base, Arbitrum, Optimism, and Polygon
- remove per-chain API key env var guidance from CLI help and README
- add/update config test coverage for single-key behavior across all supported chains

Validation:
- bun run check
- bun test test/config.test.ts