### PR TITLE
feat(cli): make scan output width-aware across terminal sizes

### DIFF
--- a/docs/research/cli-ux-width-audit-2026-02-09.md
+++ b/docs/research/cli-ux-width-audit-2026-02-09.md
@@ -1,0 +1,149 @@
+# Assay CLI UX Width Audit (2026-02-09)
+
+## Scope
+Audit of `assay scan` text output aesthetics/readability across terminal widths, with emphasis on:
+
+1. Visual polish + clarity at narrow / medium / wide widths
+2. Graceful handling of wrapping/truncation/box layout
+3. Prioritized recommendations (quick wins vs deeper refactors)
+4. Low-risk implementation of top improvements
+
+## Method
+- Reviewed renderer implementation (`src/cli/ui.ts`, `src/cli/index.ts`) and snapshot fixtures in `test/fixtures/recordings/*`.
+- Measured rendered line widths from fixture outputs.
+- Validated behavior at representative widths:
+  - **Narrow:** 80 cols
+  - **Medium:** 120 cols
+  - **Wide:** 160 cols
+- Applied frontend-design rubric principles to terminal UI:
+  - clear hierarchy
+  - scan-first information architecture
+  - resilient layout under constraints
+  - consistent spacing rhythm
+
+---
+
+## Baseline Findings (Before)
+
+### 1) Width behavior: content-defined, not viewport-defined
+The box width was set to the longest line in content. No awareness of terminal width (`process.stdout.columns`).
+
+**Observed max widths (visible columns):**
+- `north-star__approve-unlimited-sim-not-run`: **138**
+- `wallet-transferfrom-failed-8362e95e`: **117**
+- `north-star__swap-sim-failed`: **85**
+- `wallet-*swap/approve`: **83**
+
+**Overflow rate from fixtures (7 bundles):**
+- At 80 cols: **5/7 overflow**
+- At 100 cols: **2/7 overflow**
+- At 120 cols: **1/7 overflow**
+
+### 2) Primary overflow driver
+The long `INCONCLUSIVE` risk line frequently set the entire box width, e.g.:
+
+- `⚠️ INCONCLUSIVE: simulation failed (...) — balances/approvals may be unknown`
+
+This made otherwise tidy cards become horizontally brittle on narrow and medium terminals.
+
+### 3) Aesthetic impact
+- Good: clear sectioning, semantic icons, strong contrast, predictable vertical structure.
+- Weakness: when one line grows, the whole card loses composure and becomes hard to parse in smaller terminals.
+
+---
+
+## Implemented Improvements (Low Risk)
+
+### ✅ Improvement 1: Width-aware word wrapping in box renderer
+Implemented ANSI-preserving line wrapping in `src/cli/ui.ts`:
+- Added `wrapBoxLine(...)` and `wrapAllLines(...)`
+- Added optional `maxWidth` support to:
+  - `renderUnifiedBox(...)`
+  - `renderBox(...)`
+  - `renderResultBox(...)`
+  - `renderApprovalBox(...)`
+
+Behavior:
+- If `maxWidth` is provided, long lines wrap by words.
+- Continuation lines gain slight extra indent for readability.
+- No truncation (content preserved).
+- Backwards-compatible when `maxWidth` is omitted.
+
+### ✅ Improvement 2: Pass terminal width from CLI entry points
+In `src/cli/index.ts`, added `terminalWidth()` and passed it into rendered text paths:
+- `assay analyze`
+- `assay scan` (text mode)
+- `assay approval`
+- proxy wallet-mode rendered summaries
+
+This activates width-aware wrapping automatically in interactive terminals.
+
+---
+
+## Before / After Notes
+
+### Before (80-col terminal, problematic case)
+- Box expanded to **117+ cols** for long risk lines.
+- Horizontal overflow required wrapping by terminal emulator (breaking visual structure).
+
+### After (80-col terminal)
+- Same content stays within terminal width.
+- Box borders remain intact.
+- Long risk lines wrap into aligned continuation lines.
+
+### Quantitative check (north-star bundles)
+- **Before:**
+  - overflow >80: **2/4**
+  - overflow >100: **1/4**
+  - overflow >120: **1/4**
+- **After** (render with `maxWidth`):
+  - overflow >80: **0/4**
+  - overflow >100: **0/4**
+  - overflow >120: **0/4**
+
+---
+
+## Tradeoffs
+
+1. **Pros**
+   - Big readability win at narrow widths
+   - No data loss (word-wrap, not truncation)
+   - Preserves existing UX and snapshots when width clamp is absent
+   - Low implementation risk
+
+2. **Cons / constraints**
+   - Wrapping currently uses simple visible-length logic (no full grapheme-width engine), so some exotic emoji/font environments may still have minor alignment variance.
+   - Box width is an upper-bound clamp, not forced fill to terminal width (intentional to avoid noisy whitespace).
+
+---
+
+## Prioritized Recommendations
+
+### Quick wins (next)
+1. **Section-level compact mode for <90 cols**
+   - Collapse low-priority lines (e.g., secondary safe findings) behind a concise summary line.
+2. **Message length budgeting for high-variance strings**
+   - Keep verbose risk explanations in 1–2 wrapped clauses with stable rhythm.
+
+### Deeper refactors
+3. **Adaptive layout tiers (80 / 120 / 160+)**
+   - Small: compact labels + fewer ornaments
+   - Medium: current card
+   - Wide: richer details inline
+4. **Design-system pass for terminal tokens**
+   - Standardize indentation, bullets, and section header rhythm via centralized constants.
+5. **Optional “headline verdict” strip**
+   - One-line top summary (`SAFE / LOW / MEDIUM / HIGH`) before details for scan-at-a-glance workflows.
+
+---
+
+## 11/10 Polish Path
+
+To reach “11/10” CLI polish:
+1. Keep current wrapping foundation (done).
+2. Add **responsive density modes** by width tier.
+3. Add a **top-level verdict headline** + **actionable next step** line.
+4. Normalize message copy to a tighter editorial style (short clauses, consistent verb forms).
+5. Add fixture-backed visual contracts for 80/100/120/160 widths.
+
+This yields an interface that remains legible under pressure, scales elegantly across terminal sizes, and feels intentionally designed rather than merely formatted.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,11 @@ import {
 
 const VALID_CHAINS: Chain[] = ["ethereum", "base", "arbitrum", "optimism", "polygon"];
 
+/** Return the terminal width when running interactively, undefined otherwise. */
+function terminalWidth(): number | undefined {
+	return process.stdout.columns || undefined;
+}
+
 type OptionSpec = { takesValue: boolean };
 
 type CommandOptionSpecs = Record<string, OptionSpec>;
@@ -332,6 +337,7 @@ async function runScan(args: string[]) {
 							hasCalldata: Boolean(parsed.data.calldata),
 							sender: parsed.data.calldata?.from,
 							verbose,
+							maxWidth: terminalWidth(),
 						});
 
 		await writeOutput(output, outputPayload, format === "text");
@@ -467,7 +473,7 @@ async function runApproval(args: string[]) {
 
 		const result = await analyzeApproval(tx, chain, context, config, { offline });
 
-		console.log(renderApprovalBox(tx, chain, context, result));
+		console.log(renderApprovalBox(tx, chain, context, result, terminalWidth()));
 		console.log("");
 
 		if (result.recommendation === "danger") {
@@ -568,6 +574,7 @@ async function runProxy(args: string[]) {
 								{
 									hasCalldata: Boolean(input.calldata),
 									sender: input.calldata?.from,
+									maxWidth: terminalWidth(),
 								},
 							)}\n`;
 

--- a/test/ui-wrap.test.ts
+++ b/test/ui-wrap.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { renderResultBox } from "../src/cli/ui";
+import type { AnalysisResult } from "../src/types";
+
+function stripAnsi(input: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequence
+	return input.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+function baseAnalysis(): AnalysisResult {
+	return {
+		contract: {
+			address: "0x1111111111111111111111111111111111111111",
+			chain: "ethereum",
+			verified: true,
+			confidence: "high",
+			is_proxy: false,
+		},
+		findings: [],
+		recommendation: "ok",
+	};
+}
+
+describe("box width-aware wrapping", () => {
+	test("without maxWidth, box expands freely (backwards compat)", () => {
+		const analysis: AnalysisResult = {
+			...baseAnalysis(),
+			simulation: {
+				success: false,
+				revertReason: "execution reverted: transferFrom failed",
+				balances: { changes: [], confidence: "low" },
+				approvals: { changes: [], confidence: "low" },
+				notes: ["Simulation failed"],
+			},
+		};
+
+		const output = stripAnsi(renderResultBox(analysis, { hasCalldata: true }));
+		const lines = output.split("\n");
+		// All box lines should be the same width
+		const boxLines = lines.filter((line) => line.startsWith("│") || line.startsWith("┌"));
+		const widths = boxLines.map((line) => line.length);
+		const maxWidth = Math.max(...widths);
+		// Without clamping the INCONCLUSIVE line drives the box wider than 80
+		expect(maxWidth).toBeGreaterThan(80);
+		// All box lines must be the same width (uniform box)
+		for (const w of widths) {
+			expect(w).toBe(maxWidth);
+		}
+	});
+
+	test("with maxWidth=80, all box lines fit within 80 columns", () => {
+		const analysis: AnalysisResult = {
+			...baseAnalysis(),
+			simulation: {
+				success: false,
+				revertReason: "execution reverted: transferFrom failed",
+				balances: { changes: [], confidence: "low" },
+				approvals: { changes: [], confidence: "low" },
+				notes: ["Simulation failed"],
+			},
+		};
+
+		const output = stripAnsi(renderResultBox(analysis, { hasCalldata: true, maxWidth: 80 }));
+		const lines = output.split("\n");
+		for (const line of lines) {
+			if (line.length === 0) continue;
+			expect(line.length).toBeLessThanOrEqual(80);
+		}
+	});
+
+	test("content is preserved across wrapping (no truncation)", () => {
+		const analysis: AnalysisResult = {
+			...baseAnalysis(),
+			simulation: {
+				success: false,
+				revertReason: "execution reverted: transferFrom failed",
+				balances: { changes: [], confidence: "low" },
+				approvals: { changes: [], confidence: "low" },
+				notes: ["Simulation failed"],
+			},
+		};
+
+		const wide = stripAnsi(renderResultBox(analysis, { hasCalldata: true }));
+		const narrow = stripAnsi(renderResultBox(analysis, { hasCalldata: true, maxWidth: 80 }));
+
+		// Wrapping should change line breaks for long content
+		expect(narrow).not.toBe(wide);
+		// INCONCLUSIVE should still appear in wrapped output
+		expect(narrow).toContain("INCONCLUSIVE");
+		// The full revert reason should still be present
+		expect(narrow).toContain("transferFrom failed");
+		// Recommendation label should be present
+		expect(narrow).toContain("RECOMMENDATION:");
+	});
+
+	test("wrapped continuation lines are indented", () => {
+		const analysis: AnalysisResult = {
+			...baseAnalysis(),
+			simulation: {
+				success: false,
+				revertReason: "execution reverted: transferFrom failed",
+				balances: { changes: [], confidence: "low" },
+				approvals: { changes: [], confidence: "low" },
+				notes: ["Simulation failed"],
+			},
+		};
+
+		const output = stripAnsi(renderResultBox(analysis, { hasCalldata: true, maxWidth: 60 }));
+		const lines = output.split("\n");
+		// At narrow width, the INCONCLUSIVE line should be wrapped.
+		// Verify the box is well-formed: every content line starts with │
+		const contentLines = lines.filter(
+			(line) => line.startsWith("│") && !line.startsWith("├") && !line.startsWith("└"),
+		);
+		for (const line of contentLines) {
+			expect(line).toMatch(/^│.*│$/);
+		}
+	});
+
+	test("small content does not wrap when maxWidth is generous", () => {
+		const analysis = baseAnalysis();
+
+		const wide = stripAnsi(renderResultBox(analysis, { hasCalldata: false }));
+		const clamped = stripAnsi(renderResultBox(analysis, { hasCalldata: false, maxWidth: 200 }));
+
+		// When maxWidth is larger than content, output should be identical
+		expect(clamped).toBe(wide);
+	});
+});


### PR DESCRIPTION
## Summary
UX audit + low-risk implementation for Assay CLI text output readability across terminal sizes.

This PR addresses the highest-impact issue found in the audit: box output width was content-driven, so a single long line (usually INCONCLUSIVE risk detail) forced horizontal overflow in narrow/medium terminals.

### What changed
- Added **width-aware wrapping** for boxed UI lines in `src/cli/ui.ts`
  - new `wrapBoxLine(...)` + `wrapAllLines(...)`
  - supports ANSI-preserving wrapping for colored text
  - wraps by words (no truncation)
  - continuation lines are slightly indented for readability
- Added optional `maxWidth` support to:
  - `renderResultBox(...)`
  - `renderApprovalBox(...)`
  - internal `renderUnifiedBox(...)` / `renderBox(...)`
- Wired terminal width from CLI entry points in `src/cli/index.ts`
  - `assay analyze`
  - `assay scan` (text mode)
  - `assay approval`
  - proxy wallet-mode rendered summary
- Added regression coverage in `test/ui-wrap.test.ts`
- Added audit report in `docs/research/cli-ux-width-audit-2026-02-09.md`

## Before / After notes
### Before
- Box width expanded to longest content line.
- Observed fixture widths up to **138 cols** (`north-star__approve-unlimited-sim-not-run`), causing overflow in 80-col terminals.
- Overflow incidence from recordings:
  - >80: **5/7**
  - >100: **2/7**
  - >120: **1/7**

### After
- In interactive terminals, output now wraps to `process.stdout.columns`.
- No truncation; content preserved and wrapped.
- For north-star fixtures rendered with width clamp:
  - `maxWidth=80`: **0/4 overflow**
  - `maxWidth=100`: **0/4 overflow**
  - `maxWidth=120`: **0/4 overflow**

## Tradeoffs
- Uses simple visible-length wrapping (ANSI-aware), not a full grapheme-width engine; should be robust for common terminals but may have minor edge alignment differences for rare emoji/font combos.
- Width clamp acts as an upper bound (does not force full terminal width, intentionally).

## Checks
- `bun run check` ✅
- `bun run test` ✅
  - 118 pass / 56 skip / 4 todo / 0 fail

