### PR TITLE
feat: instrument non-proxy surfaces + rollup script + prove-kill docs (#124 PR2)

### DIFF
--- a/docs/artifacts/prove-kill-week1.md
+++ b/docs/artifacts/prove-kill-week1.md
@@ -1,0 +1,49 @@
+# Prove/Kill Week 1 Scorecard Template
+
+> Window: YYYY-MM-DD → YYYY-MM-DD (UTC)
+> Owner: @___
+> Data source: `~/.config/assay/telemetry/events/*.jsonl`
+
+## Daily rollup command
+
+```bash
+bun run scripts/rollup-prove-kill.ts \
+  --date YYYY-MM-DD \
+  --window-days 7 \
+  --out docs/artifacts/rollups/YYYY-MM-DD.json
+```
+
+Notes:
+- `--date` uses **UTC day** (matches telemetry file naming: `YYYY-MM-DD.jsonl`).
+- Script output prints a markdown snapshot to stdout and writes structured JSON when `--out` is provided.
+
+## Daily snapshots
+
+| Date (UTC) | Decision sessions | Proceed rate (all) | Block rate (all) | WAU installs | Returning install rate | Edit-and-retry inferred |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| YYYY-MM-DD |  |  |  |  |  |  |
+| YYYY-MM-DD |  |  |  |  |  |  |
+| YYYY-MM-DD |  |  |  |  |  |  |
+| YYYY-MM-DD |  |  |  |  |  |  |
+| YYYY-MM-DD |  |  |  |  |  |  |
+| YYYY-MM-DD |  |  |  |  |  |  |
+| YYYY-MM-DD |  |  |  |  |  |  |
+
+## Severity breakdown (end-of-week)
+
+- SAFE: proceed ___ / block ___ / error ___
+- CAUTION: proceed ___ / block ___ / error ___
+- WARNING: proceed ___ / block ___ / error ___
+- BLOCK: proceed ___ / block ___ / error ___
+
+## Week 1 narrative
+
+- What changed in user behavior after warnings?
+- Any sign of repeat voluntary usage?
+- Where telemetry is still ambiguous/noisy?
+
+## Decision checkpoint (prove / kill / continue)
+
+- **Recommendation:** ___
+- **Rationale:** ___
+- **Gaps to close in Week 2:** ___

--- a/scripts/rollup-prove-kill.ts
+++ b/scripts/rollup-prove-kill.ts
@@ -1,0 +1,386 @@
+#!/usr/bin/env bun
+
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { type TelemetryEvent, telemetryEventSchema } from "../src/telemetry";
+
+type OutcomeEvent = Extract<TelemetryEvent, { event: "user_action_outcome" }>;
+
+type RollupArgs = {
+	date: string;
+	eventsDir: string;
+	windowDays: number;
+	outputPath?: string;
+};
+
+type BucketStats = {
+	total: number;
+	forwarded: number;
+	blocked: number;
+	errored: number;
+	forwardRate: number;
+	blockRate: number;
+};
+
+type RollupSummary = {
+	date: string;
+	eventsDir: string;
+	parsedEvents: number;
+	invalidLinesDropped: number;
+	decisionSessions: number;
+	outcomesTotal: number;
+	proceedBlockBySeverity: Record<"SAFE" | "CAUTION" | "WARNING" | "BLOCK", BucketStats>;
+	repeatUse: {
+		dauInstalls: number;
+		wauInstalls: number;
+		returningInstallCount: number;
+		returningInstallRate: number;
+		dauWallets: number;
+		returningWalletCount: number;
+		returningWalletRate: number;
+	};
+	editRetryInference: {
+		blockedOutcomes: number;
+		retryAfterBlockWithin30m: number;
+		editAndRetryInferred: number;
+		retrySameFingerprint: number;
+		retryFingerprintUnknown: number;
+	};
+	filesScanned: string[];
+};
+
+function defaultEventsDir(): string {
+	return path.join(os.homedir(), ".config", "assay", "telemetry", "events");
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+	if (!value) return fallback;
+	const parsed = Number.parseInt(value, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		throw new Error(`Invalid numeric value: ${value}`);
+	}
+	return parsed;
+}
+
+function parseArgs(argv: string[]): RollupArgs {
+	const date = getFlagValue(argv, "--date") ?? new Date().toISOString().slice(0, 10);
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+		throw new Error(`Invalid --date value: ${date} (expected YYYY-MM-DD, UTC)`);
+	}
+	const eventsDir = getFlagValue(argv, "--events-dir") ?? defaultEventsDir();
+	const windowDays = parsePositiveInt(getFlagValue(argv, "--window-days"), 7);
+	const outputPath = getFlagValue(argv, "--out");
+	return { date, eventsDir, windowDays, outputPath };
+}
+
+function getFlagValue(args: string[], flag: string): string | undefined {
+	const index = args.indexOf(flag);
+	if (index === -1) return undefined;
+	return args[index + 1];
+}
+
+function dateOffsets(endDate: string, days: number): string[] {
+	const end = new Date(`${endDate}T00:00:00.000Z`);
+	if (Number.isNaN(end.getTime())) {
+		throw new Error(`Invalid date: ${endDate}`);
+	}
+	const result: string[] = [];
+	for (let i = 0; i < days; i += 1) {
+		const current = new Date(end);
+		current.setUTCDate(end.getUTCDate() - i);
+		result.push(current.toISOString().slice(0, 10));
+	}
+	return result;
+}
+
+async function readEvents(
+	filePath: string,
+): Promise<{ events: TelemetryEvent[]; invalid: number }> {
+	if (!existsSync(filePath)) {
+		return { events: [], invalid: 0 };
+	}
+	const raw = await readFile(filePath, "utf-8");
+	if (raw.trim().length === 0) {
+		return { events: [], invalid: 0 };
+	}
+
+	const events: TelemetryEvent[] = [];
+	let invalid = 0;
+	for (const line of raw.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsedJson = JSON.parse(trimmed);
+			const parsed = telemetryEventSchema.safeParse(parsedJson);
+			if (!parsed.success) {
+				invalid += 1;
+				continue;
+			}
+			events.push(parsed.data);
+		} catch {
+			invalid += 1;
+		}
+	}
+	return { events, invalid };
+}
+
+function uniqueSet(values: Array<string | null | undefined>): Set<string> {
+	const result = new Set<string>();
+	for (const value of values) {
+		if (!value) continue;
+		result.add(value);
+	}
+	return result;
+}
+
+function toOutcomeEvent(event: TelemetryEvent): OutcomeEvent | null {
+	if (event.event !== "user_action_outcome") return null;
+	return event;
+}
+
+function buildBucketStats(outcomes: OutcomeEvent[]): RollupSummary["proceedBlockBySeverity"] {
+	const buckets: RollupSummary["proceedBlockBySeverity"] = {
+		SAFE: makeEmptyBucket(),
+		CAUTION: makeEmptyBucket(),
+		WARNING: makeEmptyBucket(),
+		BLOCK: makeEmptyBucket(),
+	};
+
+	for (const outcome of outcomes) {
+		const target = buckets[outcome.severityBucket];
+		target.total += 1;
+		if (outcome.decision === "forwarded") {
+			target.forwarded += 1;
+		} else if (outcome.decision === "error") {
+			target.errored += 1;
+		} else {
+			target.blocked += 1;
+		}
+	}
+
+	for (const bucket of Object.values(buckets)) {
+		if (bucket.total > 0) {
+			bucket.forwardRate = bucket.forwarded / bucket.total;
+			bucket.blockRate = bucket.blocked / bucket.total;
+		}
+	}
+
+	return buckets;
+}
+
+function makeEmptyBucket(): BucketStats {
+	return {
+		total: 0,
+		forwarded: 0,
+		blocked: 0,
+		errored: 0,
+		forwardRate: 0,
+		blockRate: 0,
+	};
+}
+
+function inferEditRetries(outcomes: OutcomeEvent[]): RollupSummary["editRetryInference"] {
+	const sorted = [...outcomes].sort((a, b) => a.ts.localeCompare(b.ts));
+	let blockedOutcomes = 0;
+	let retryAfterBlockWithin30m = 0;
+	let editAndRetryInferred = 0;
+	let retrySameFingerprint = 0;
+	let retryFingerprintUnknown = 0;
+
+	for (let i = 0; i < sorted.length; i += 1) {
+		const current = sorted[i];
+		if (!current || current.decision === "forwarded" || current.decision === "error") continue;
+		blockedOutcomes += 1;
+
+		const startedAt = Date.parse(current.ts);
+		if (Number.isNaN(startedAt)) continue;
+
+		for (let j = i + 1; j < sorted.length; j += 1) {
+			const next = sorted[j];
+			if (!next || next.installId !== current.installId) continue;
+			if (next.chain !== current.chain) continue;
+			const nextAt = Date.parse(next.ts);
+			if (Number.isNaN(nextAt)) continue;
+			if (nextAt - startedAt > 30 * 60 * 1000) break;
+			if (next.decision !== "forwarded") continue;
+
+			retryAfterBlockWithin30m += 1;
+			if (!current.actionFingerprint || !next.actionFingerprint) {
+				retryFingerprintUnknown += 1;
+				break;
+			}
+			if (current.actionFingerprint === next.actionFingerprint) {
+				retrySameFingerprint += 1;
+			} else {
+				editAndRetryInferred += 1;
+			}
+			break;
+		}
+	}
+
+	return {
+		blockedOutcomes,
+		retryAfterBlockWithin30m,
+		editAndRetryInferred,
+		retrySameFingerprint,
+		retryFingerprintUnknown,
+	};
+}
+
+function percent(value: number): string {
+	return `${(value * 100).toFixed(1)}%`;
+}
+
+function renderReport(summary: RollupSummary): string {
+	const lines: string[] = [];
+	lines.push(`# Assay prove/kill rollup — ${summary.date} (UTC)`);
+	lines.push("");
+	lines.push(`- Events dir: ${summary.eventsDir}`);
+	lines.push(`- Files scanned: ${summary.filesScanned.length}`);
+	lines.push(`- Parsed events: ${summary.parsedEvents}`);
+	lines.push(`- Dropped invalid lines: ${summary.invalidLinesDropped}`);
+	lines.push("");
+	lines.push("## Decision sessions");
+	lines.push(`- Decision sessions (unique correlation IDs): ${summary.decisionSessions}`);
+	lines.push(`- user_action_outcome events: ${summary.outcomesTotal}`);
+	lines.push("");
+	lines.push("## Proceed/block by severity");
+	const severities: Array<"SAFE" | "CAUTION" | "WARNING" | "BLOCK"> = [
+		"SAFE",
+		"CAUTION",
+		"WARNING",
+		"BLOCK",
+	];
+	for (const severity of severities) {
+		const stats = summary.proceedBlockBySeverity[severity];
+		lines.push(
+			`- ${severity}: total=${stats.total}, proceed=${stats.forwarded} (${percent(stats.forwardRate)}), block=${stats.blocked} (${percent(stats.blockRate)}), error=${stats.errored}`,
+		);
+	}
+	lines.push("");
+	lines.push("## Repeat-use snapshot");
+	lines.push(`- DAU installs: ${summary.repeatUse.dauInstalls}`);
+	lines.push(
+		`- WAU installs (${summary.date} trailing 7d default): ${summary.repeatUse.wauInstalls}`,
+	);
+	lines.push(
+		`- Returning installs today: ${summary.repeatUse.returningInstallCount} (${percent(summary.repeatUse.returningInstallRate)})`,
+	);
+	lines.push(`- DAU wallets (hashed): ${summary.repeatUse.dauWallets}`);
+	lines.push(
+		`- Returning wallets today: ${summary.repeatUse.returningWalletCount} (${percent(summary.repeatUse.returningWalletRate)})`,
+	);
+	lines.push("");
+	lines.push("## Edit-retry inference (heuristic)");
+	lines.push(`- Blocked outcomes: ${summary.editRetryInference.blockedOutcomes}`);
+	lines.push(
+		`- Retry-after-block within 30m: ${summary.editRetryInference.retryAfterBlockWithin30m}`,
+	);
+	lines.push(`- Edit-and-retry inferred: ${summary.editRetryInference.editAndRetryInferred}`);
+	lines.push(`- Retry same fingerprint: ${summary.editRetryInference.retrySameFingerprint}`);
+	lines.push(`- Retry fingerprint unknown: ${summary.editRetryInference.retryFingerprintUnknown}`);
+	return lines.join("\n");
+}
+
+async function buildRollup(args: RollupArgs): Promise<RollupSummary> {
+	const targetDates = dateOffsets(args.date, args.windowDays);
+	const filesScanned = targetDates
+		.map((date) => path.join(args.eventsDir, `${date}.jsonl`))
+		.filter((filePath) => existsSync(filePath));
+
+	const eventsByDate = new Map<string, TelemetryEvent[]>();
+	let invalidLinesDropped = 0;
+
+	for (const date of targetDates) {
+		const filePath = path.join(args.eventsDir, `${date}.jsonl`);
+		const { events, invalid } = await readEvents(filePath);
+		eventsByDate.set(date, events);
+		invalidLinesDropped += invalid;
+	}
+
+	const dayEvents = eventsByDate.get(args.date) ?? [];
+	const trailingWindowEvents = targetDates.flatMap((date) => eventsByDate.get(date) ?? []);
+	const priorDays = targetDates.filter((date) => date !== args.date);
+	const priorEvents = priorDays.flatMap((date) => eventsByDate.get(date) ?? []);
+
+	const dayOutcomes = dayEvents
+		.map(toOutcomeEvent)
+		.filter((event): event is OutcomeEvent => event !== null);
+	const decisionSessions = uniqueSet(dayOutcomes.map((event) => event.correlationId)).size;
+
+	const dayActiveEvents = dayEvents.filter(
+		(event) =>
+			event.event === "scan_started" ||
+			event.event === "scan_result" ||
+			event.event === "user_action_outcome",
+	);
+	const priorActiveEvents = priorEvents.filter(
+		(event) =>
+			event.event === "scan_started" ||
+			event.event === "scan_result" ||
+			event.event === "user_action_outcome",
+	);
+
+	const dauInstalls = uniqueSet(dayActiveEvents.map((event) => event.installId));
+	const wauInstalls = uniqueSet(trailingWindowEvents.map((event) => event.installId));
+	const priorInstalls = uniqueSet(priorActiveEvents.map((event) => event.installId));
+	let returningInstallCount = 0;
+	for (const install of dauInstalls) {
+		if (priorInstalls.has(install)) {
+			returningInstallCount += 1;
+		}
+	}
+
+	const dauWallets = uniqueSet(dayActiveEvents.map((event) => event.actorWalletHash));
+	const priorWallets = uniqueSet(priorActiveEvents.map((event) => event.actorWalletHash));
+	let returningWalletCount = 0;
+	for (const wallet of dauWallets) {
+		if (priorWallets.has(wallet)) {
+			returningWalletCount += 1;
+		}
+	}
+
+	return {
+		date: args.date,
+		eventsDir: args.eventsDir,
+		parsedEvents: dayEvents.length,
+		invalidLinesDropped,
+		decisionSessions,
+		outcomesTotal: dayOutcomes.length,
+		proceedBlockBySeverity: buildBucketStats(dayOutcomes),
+		repeatUse: {
+			dauInstalls: dauInstalls.size,
+			wauInstalls: wauInstalls.size,
+			returningInstallCount,
+			returningInstallRate: dauInstalls.size > 0 ? returningInstallCount / dauInstalls.size : 0,
+			dauWallets: dauWallets.size,
+			returningWalletCount,
+			returningWalletRate: dauWallets.size > 0 ? returningWalletCount / dauWallets.size : 0,
+		},
+		editRetryInference: inferEditRetries(dayOutcomes),
+		filesScanned,
+	};
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const summary = await buildRollup(args);
+	const report = renderReport(summary);
+	console.log(report);
+
+	if (args.outputPath) {
+		const outputPath = path.resolve(args.outputPath);
+		await mkdir(path.dirname(outputPath), { recursive: true });
+		const payload = `${JSON.stringify(summary, null, 2)}\n`;
+		await writeFile(outputPath, payload, "utf-8");
+		console.error(`Saved JSON summary: ${outputPath}`);
+	}
+}
+
+if (import.meta.main) {
+	await main();
+}
+
+export { buildRollup, renderReport, type RollupSummary, type RollupArgs };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "../config";
 import { resolveScanChain, scan } from "../scan";
 import type { AnalyzeResponse, ScanInput } from "../schema";
 import { analyzeResponseSchema, parseScanRequest, scanRequestSchema } from "../schema";
+import { createProxyTelemetry, type ProxyTelemetry } from "../telemetry";
 import type { Config } from "../types";
 
 export interface ServerOptions {
@@ -11,12 +12,23 @@ export interface ServerOptions {
 		options?: { chain?: string; config?: Config },
 	) => Promise<AnalyzeResponse>;
 	config?: Config;
+	telemetry?: ProxyTelemetry;
 }
 
 export function createScanHandler(options: ServerOptions = {}) {
 	const apiKey = options.apiKey ?? process.env.ASSAY_API_KEY;
 	const scanFn = options.scanFn ?? scan;
 	const configPromise = options.config ? Promise.resolve(options.config) : loadConfig();
+	const telemetry =
+		options.telemetry ??
+		createProxyTelemetry({
+			source: "server",
+			onError: (error) => {
+				if (process.env.ASSAY_TELEMETRY_DEBUG !== "1") return;
+				const message = error instanceof Error ? error.message : String(error);
+				process.stderr.write(`telemetry error: ${message}\n`);
+			},
+		});
 
 	return async (request: Request): Promise<Response> => {
 		const url = new URL(request.url);
@@ -75,6 +87,26 @@ export function createScanHandler(options: ServerOptions = {}) {
 			}
 		}
 
+		const correlationId = crypto.randomUUID();
+		const startedAt = Date.now();
+		const telemetryChain =
+			resolveScanChain(parsed.input.calldata?.chain ?? parsed.chain ?? "ethereum") ?? "unknown";
+		const telemetryTarget = parsed.input.address ?? parsed.input.calldata?.to;
+		safeEmitTelemetry(() => {
+			telemetry.emitScanStarted({
+				correlationId,
+				chain: telemetryChain,
+				actorAddress: parsed.input.calldata?.from,
+				to: telemetryTarget,
+				data: parsed.input.calldata?.data ?? "0x",
+				value: parsed.input.calldata?.value,
+				method: "assay_scan",
+				inputKind: parsed.input.address ? "address" : "calldata",
+				threshold: "caution",
+				offline: false,
+			});
+		});
+
 		try {
 			const config = await configPromise;
 			const response = await scanFn(parsed.input, {
@@ -86,6 +118,22 @@ export function createScanHandler(options: ServerOptions = {}) {
 			if (!output.success) {
 				return jsonResponse({ error: "Invalid scan response" }, 500);
 			}
+
+			safeEmitTelemetry(() => {
+				telemetry.emitScanResult({
+					correlationId,
+					chain: telemetryChain,
+					actorAddress: parsed.input.calldata?.from,
+					to: telemetryTarget,
+					data: parsed.input.calldata?.data ?? "0x",
+					value: parsed.input.calldata?.value,
+					requestId: output.data.requestId,
+					recommendation: output.data.scan.recommendation,
+					simulationStatus: simulationStatusForTelemetry(output.data),
+					findingCodes: findingCodesForTelemetry(output.data),
+					latencyMs: Date.now() - startedAt,
+				});
+			});
 
 			return jsonResponse(output.data, 200);
 		} catch (error) {
@@ -108,6 +156,32 @@ function parseBearerToken(value: string | null): string | null {
 	const match = value.match(/^Bearer\s+(.+)$/i);
 	if (!match) return null;
 	return match[1]?.trim() ?? null;
+}
+
+function simulationStatusForTelemetry(response: AnalyzeResponse): "success" | "failed" | "not_run" {
+	const status = response.scan.simulation?.status;
+	if (status === "success" || status === "failed" || status === "not_run") {
+		return status;
+	}
+	return "not_run";
+}
+
+function findingCodesForTelemetry(response: AnalyzeResponse): string[] {
+	const codes: string[] = [];
+	for (const finding of response.scan.findings) {
+		if (!finding.code) continue;
+		codes.push(finding.code);
+		if (codes.length >= 5) break;
+	}
+	return codes;
+}
+
+function safeEmitTelemetry(emit: () => void): void {
+	try {
+		emit();
+	} catch {
+		// Telemetry is best-effort only.
+	}
 }
 
 function jsonResponse(body: Record<string, unknown>, status: number): Response {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -11,6 +11,7 @@ export {
 	type ProxyScanResultInput,
 	type ProxyScanStartedInput,
 	type ProxyTelemetry,
+	type ProxyTelemetryOptions,
 	type ProxyUserActionOutcomeInput,
 	type TelemetryDecision,
 	type TelemetryPromptResponse,
@@ -18,7 +19,9 @@ export {
 export {
 	type TelemetryEvent,
 	type TelemetrySeverityBucket,
+	type TelemetrySource,
 	telemetryEventSchema,
 	telemetrySeverityBucketSchema,
+	telemetrySourceSchema,
 } from "./schema";
 export { createAppendOnlyTelemetryWriter, type TelemetryWriter } from "./writer";

--- a/src/telemetry/schema.ts
+++ b/src/telemetry/schema.ts
@@ -8,6 +8,8 @@ const chainSchema = z.enum(["ethereum", "base", "arbitrum", "optimism", "polygon
 
 const hashSchema = z.string().regex(/^[a-f0-9]{64}$/);
 
+export const telemetrySourceSchema = z.enum(["proxy", "cli", "server", "sdk_viem"]);
+
 const telemetryBaseSchema = z
 	.object({
 		eventVersion: z.literal(1),
@@ -15,7 +17,7 @@ const telemetryBaseSchema = z
 		ts: z.string().datetime(),
 		sessionId: z.string().uuid(),
 		correlationId: z.string().uuid(),
-		source: z.literal("proxy"),
+		source: telemetrySourceSchema,
 		installId: hashSchema,
 		actorWalletHash: hashSchema.nullable(),
 		chain: chainSchema,
@@ -25,8 +27,13 @@ const telemetryBaseSchema = z
 const scanStartedSchema = telemetryBaseSchema
 	.extend({
 		event: z.literal("scan_started"),
-		inputKind: z.enum(["calldata", "typed_data"]),
-		method: z.enum(["eth_sendTransaction", "eth_sendRawTransaction", "eth_signTypedData_v4"]),
+		inputKind: z.enum(["address", "calldata", "typed_data"]),
+		method: z.enum([
+			"assay_scan",
+			"eth_sendTransaction",
+			"eth_sendRawTransaction",
+			"eth_signTypedData_v4",
+		]),
 		mode: z.enum(["default", "offline"]),
 		threshold: recommendationSchema,
 		txFingerprint: hashSchema.nullable(),
@@ -74,5 +81,6 @@ export const telemetryEventSchema = z.discriminatedUnion("event", [
 	userActionOutcomeSchema,
 ]);
 
+export type TelemetrySource = z.infer<typeof telemetrySourceSchema>;
 export type TelemetrySeverityBucket = z.infer<typeof telemetrySeverityBucketSchema>;
 export type TelemetryEvent = z.infer<typeof telemetryEventSchema>;

--- a/test/rollup-prove-kill.unit.test.ts
+++ b/test/rollup-prove-kill.unit.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildRollup } from "../scripts/rollup-prove-kill";
+
+function hash(char: string): string {
+	return char.repeat(64);
+}
+
+function makeBase(options: {
+	ts: string;
+	installId: string;
+	correlationId: string;
+	actorWalletHash?: string | null;
+}): {
+	eventVersion: 1;
+	eventId: string;
+	ts: string;
+	sessionId: string;
+	correlationId: string;
+	source: "sdk_viem";
+	installId: string;
+	actorWalletHash: string | null;
+	chain: "ethereum";
+} {
+	return {
+		eventVersion: 1,
+		eventId: crypto.randomUUID(),
+		ts: options.ts,
+		sessionId: crypto.randomUUID(),
+		correlationId: options.correlationId,
+		source: "sdk_viem",
+		installId: options.installId,
+		actorWalletHash: options.actorWalletHash ?? null,
+		chain: "ethereum",
+	};
+}
+
+function writeJsonl(filePath: string, events: unknown[]) {
+	const content = `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+	writeFileSync(filePath, content, "utf-8");
+}
+
+describe("rollup-prove-kill", () => {
+	test("computes decision, repeat-use, and edit-retry metrics", async () => {
+		const tmpDir = mkdtempSync(path.join(os.tmpdir(), "assay-rollup-"));
+		const installA = hash("a");
+		const installB = hash("b");
+		const walletA = hash("c");
+		const walletB = hash("d");
+
+		try {
+			const day1 = "2026-02-12";
+			const day2 = "2026-02-13";
+			writeJsonl(path.join(tmpDir, `${day1}.jsonl`), [
+				{
+					...makeBase({
+						ts: "2026-02-12T11:00:00.000Z",
+						installId: installA,
+						correlationId: crypto.randomUUID(),
+						actorWalletHash: walletA,
+					}),
+					event: "scan_started",
+					inputKind: "calldata",
+					method: "eth_sendTransaction",
+					mode: "default",
+					threshold: "caution",
+					txFingerprint: hash("1"),
+					actionFingerprint: hash("2"),
+				},
+			]);
+
+			const blockedCorrelation = crypto.randomUUID();
+			const retryCorrelation = crypto.randomUUID();
+			const safeCorrelation = crypto.randomUUID();
+
+			writeJsonl(path.join(tmpDir, `${day2}.jsonl`), [
+				{
+					...makeBase({
+						ts: "2026-02-13T10:00:00.000Z",
+						installId: installA,
+						correlationId: blockedCorrelation,
+						actorWalletHash: walletA,
+					}),
+					event: "scan_started",
+					inputKind: "calldata",
+					method: "eth_sendTransaction",
+					mode: "default",
+					threshold: "caution",
+					txFingerprint: hash("3"),
+					actionFingerprint: hash("4"),
+				},
+				{
+					...makeBase({
+						ts: "2026-02-13T10:00:05.000Z",
+						installId: installA,
+						correlationId: blockedCorrelation,
+						actorWalletHash: walletA,
+					}),
+					event: "scan_result",
+					requestId: crypto.randomUUID(),
+					recommendation: "danger",
+					severityBucket: "BLOCK",
+					simulationStatus: "failed",
+					findingCodes: ["APPROVAL_MAX"],
+					latencyMs: 100,
+				},
+				{
+					...makeBase({
+						ts: "2026-02-13T10:00:06.000Z",
+						installId: installA,
+						correlationId: blockedCorrelation,
+						actorWalletHash: walletA,
+					}),
+					event: "user_action_outcome",
+					requestId: crypto.randomUUID(),
+					recommendation: "danger",
+					severityBucket: "BLOCK",
+					decision: "blocked_policy",
+					prompted: false,
+					promptResponse: "na",
+					upstreamForwarded: false,
+					txFingerprint: hash("3"),
+					actionFingerprint: hash("4"),
+				},
+				{
+					...makeBase({
+						ts: "2026-02-13T10:05:00.000Z",
+						installId: installA,
+						correlationId: retryCorrelation,
+						actorWalletHash: walletA,
+					}),
+					event: "scan_result",
+					requestId: crypto.randomUUID(),
+					recommendation: "caution",
+					severityBucket: "CAUTION",
+					simulationStatus: "success",
+					findingCodes: ["APPROVAL_LIMITED"],
+					latencyMs: 80,
+				},
+				{
+					...makeBase({
+						ts: "2026-02-13T10:05:01.000Z",
+						installId: installA,
+						correlationId: retryCorrelation,
+						actorWalletHash: walletA,
+					}),
+					event: "user_action_outcome",
+					requestId: crypto.randomUUID(),
+					recommendation: "caution",
+					severityBucket: "CAUTION",
+					decision: "forwarded",
+					prompted: false,
+					promptResponse: "na",
+					upstreamForwarded: true,
+					txFingerprint: hash("5"),
+					actionFingerprint: hash("6"),
+				},
+				{
+					...makeBase({
+						ts: "2026-02-13T11:00:00.000Z",
+						installId: installB,
+						correlationId: safeCorrelation,
+						actorWalletHash: walletB,
+					}),
+					event: "user_action_outcome",
+					requestId: crypto.randomUUID(),
+					recommendation: "ok",
+					severityBucket: "SAFE",
+					decision: "forwarded",
+					prompted: false,
+					promptResponse: "na",
+					upstreamForwarded: true,
+					txFingerprint: hash("7"),
+					actionFingerprint: hash("8"),
+				},
+			]);
+
+			const summary = await buildRollup({
+				date: day2,
+				eventsDir: tmpDir,
+				windowDays: 7,
+			});
+
+			expect(summary.decisionSessions).toBe(3);
+			expect(summary.outcomesTotal).toBe(3);
+			expect(summary.proceedBlockBySeverity.BLOCK.blocked).toBe(1);
+			expect(summary.proceedBlockBySeverity.CAUTION.forwarded).toBe(1);
+			expect(summary.repeatUse.dauInstalls).toBe(2);
+			expect(summary.repeatUse.returningInstallCount).toBe(1);
+			expect(summary.editRetryInference.retryAfterBlockWithin30m).toBe(1);
+			expect(summary.editRetryInference.editAndRetryInferred).toBe(1);
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { createScanHandler } from "../src/server";
+import { createAppendOnlyTelemetryWriter, createProxyTelemetry } from "../src/telemetry";
 
 const fixturePath = "test/fixtures/scan-response.json";
 
@@ -60,5 +64,50 @@ describe("server", () => {
 		const body = await response.json();
 		expect(response.status).toBe(200);
 		expect(body).toEqual(fixture);
+	});
+
+	test("emits telemetry for /v1/scan success", async () => {
+		const tmpDir = mkdtempSync(path.join(os.tmpdir(), "assay-server-telemetry-"));
+		const filePath = path.join(tmpDir, "events.jsonl");
+
+		try {
+			const writer = createAppendOnlyTelemetryWriter({ filePath });
+			const telemetry = createProxyTelemetry({
+				source: "server",
+				env: { ASSAY_TELEMETRY_SALT: "test-salt" },
+				writer,
+			});
+			const fixture = await readFixture();
+			const handler = createScanHandler({
+				apiKey: "test",
+				scanFn: async () => fixture,
+				config: {},
+				telemetry,
+			});
+
+			const response = await handler(
+				new Request("http://localhost/v1/scan", {
+					method: "POST",
+					headers: { authorization: "Bearer test", "content-type": "application/json" },
+					body: JSON.stringify({
+						address: "0x1111111111111111111111111111111111111111",
+						chain: "1",
+					}),
+				}),
+			);
+			expect(response.status).toBe(200);
+
+			await telemetry.flush();
+			const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+			expect(lines.length).toBe(2);
+			const started = JSON.parse(lines[0]);
+			const result = JSON.parse(lines[1]);
+			expect(started.event).toBe("scan_started");
+			expect(started.source).toBe("server");
+			expect(result.event).toBe("scan_result");
+			expect(result.source).toBe("server");
+		} finally {
+			rmSync(tmpDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/test/telemetry.unit.test.ts
+++ b/test/telemetry.unit.test.ts
@@ -285,6 +285,22 @@ describe("telemetry event schema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	test("scan_started validates for cli address scans", () => {
+		const event = {
+			...base,
+			source: "cli" as const,
+			event: "scan_started" as const,
+			inputKind: "address" as const,
+			method: "assay_scan" as const,
+			mode: "default" as const,
+			threshold: "caution" as const,
+			txFingerprint: hashWithSalt("tx", salt),
+			actionFingerprint: hashWithSalt("action", salt),
+		};
+		const result = telemetryEventSchema.safeParse(event);
+		expect(result.success).toBe(true);
+	});
+
 	test("scan_result validates", () => {
 		const event = {
 			...base,


### PR DESCRIPTION
## PR2 for #124: prove/kill sprint measurement layer

### What

Extends telemetry from PR1 (proxy-only) to all non-proxy scan surfaces, adds a daily rollup script for key metrics, and ships the prove-kill week-1 scorecard template.

### Telemetry instrumentation

| Surface | Source | Events |
|---------|--------|--------|
| `src/cli/index.ts` (runScan) | `cli` | `scan_started`, `scan_result` |
| `src/server/index.ts` (HTTP /v1/scan) | `server` | `scan_started`, `scan_result` |
| `src/sdk/viem.ts` (viem transport) | `sdk_viem` | `scan_started`, `scan_result`, `user_action_outcome` |

All telemetry is:
- Best-effort / non-blocking (never throws)
- Privacy-safe (hashed addresses, no raw calldata bodies)
- Opt-out via `ASSAY_TELEMETRY=0`

### Schema changes (backward-compatible)
- `source`: expanded from `proxy` → `proxy | cli | server | sdk_viem`
- `inputKind`: expanded from `calldata | typed_data` → `address | calldata | typed_data`
- `method`: expanded from `eth_send*` → `assay_scan | eth_send* | eth_signTypedData_v4`

### Rollup script (`scripts/rollup-prove-kill.ts`)
```bash
bun run scripts/rollup-prove-kill.ts --date 2026-02-13 --window-days 7
```
Computes:
- Decision sessions (unique correlation IDs)
- Proceed/block rates by severity bucket (SAFE/CAUTION/WARNING/BLOCK)
- DAU/WAU installs + returning-install rate
- DAU wallets + returning-wallet rate
- Edit-retry inference (blocked → forwarded within 30m, fingerprint comparison)

### Docs
- `docs/artifacts/prove-kill-week1.md`: weekly scorecard template + daily rollup runbook

### Validation
- ✅ `bun run check` — 0 errors
- ✅ `bun run build` (tsc) — 0 errors
- ✅ `bun test` — 360 pass / 86 skip / 0 fail

### Invariants preserved
- No changes to risk/recommendation thresholds or policy behavior
- All existing tests pass unchanged
- Surgical diff: 12 files, ~1000 lines added

Closes milestone: #124 PR2